### PR TITLE
Fix - Crash when tapping on an address on iPad

### DIFF
--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -36,24 +36,24 @@ struct CentreViewData: CentreViewDataProvider, Hashable {
 }
 
 class CentreCell: UITableViewCell {
-    @IBOutlet var dateContainer: UIStackView!
-    @IBOutlet var dateIconContainer: UIView!
+    @IBOutlet private var dateContainer: UIStackView!
+    @IBOutlet private var dateIconContainer: UIView!
     @IBOutlet private var dateLabel: UILabel!
 
-    @IBOutlet var addressNameContainer: UIStackView!
-    @IBOutlet var addressNameIconContainer: UIView!
+    @IBOutlet private(set) var addressNameContainer: UIStackView!
+    @IBOutlet private var addressNameIconContainer: UIView!
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var addressLabel: UILabel!
 
-    @IBOutlet var phoneNumberContainer: UIStackView!
-    @IBOutlet var phoneNumberIconContainer: UIView!
+    @IBOutlet private var phoneNumberContainer: UIStackView!
+    @IBOutlet private var phoneNumberIconContainer: UIView!
     @IBOutlet private var phoneButton: UIButton!
 
-    @IBOutlet var vaccineTypesContainer: UIStackView!
+    @IBOutlet private var vaccineTypesContainer: UIStackView!
     @IBOutlet private var vaccineTypesLabel: UILabel!
 
-    @IBOutlet var vaccineTypesIconContainer: UIView!
-    @IBOutlet var dosesLabel: UILabel!
+    @IBOutlet private var vaccineTypesIconContainer: UIView!
+    @IBOutlet private var dosesLabel: UILabel!
 
     @IBOutlet private var bookingButton: UIButton!
     @IBOutlet private var cellContentView: UIView!

--- a/ViteMaDose/Views/CentresList/CentresListViewController.swift
+++ b/ViteMaDose/Views/CentresList/CentresListViewController.swift
@@ -229,7 +229,11 @@ extension CentresListViewController {
             let mapItem = MKMapItem(placemark: placemark)
             mapItem.name = centreInfo.name
 
-            self?.presentOpenMapAlert(address: centreInfo.address, mapItem: mapItem)
+            self?.presentOpenMapAlert(
+                sourceView: cell.addressNameContainer,
+                address: centreInfo.address,
+                mapItem: mapItem
+            )
         }
         // Phone number tap
         cell.phoneNumberTapHandler = { [weak self] in
@@ -243,7 +247,11 @@ extension CentresListViewController {
         }
     }
 
-    private func presentOpenMapAlert(address: String?, mapItem: MKMapItem) {
+    private func presentOpenMapAlert(
+        sourceView: UIView,
+        address: String?,
+        mapItem: MKMapItem
+    ) {
         let actionSheet = UIAlertController(
             title: mapItem.name,
             message: address,
@@ -264,6 +272,8 @@ extension CentresListViewController {
         actionSheet.addAction(openAction)
         actionSheet.addAction(cancelAction)
         actionSheet.preferredAction = openAction
+        actionSheet.popoverPresentationController?.sourceView = sourceView
+
         present(actionSheet, animated: true)
     }
 }


### PR DESCRIPTION
## Description
Tapping on a centre address would make the app crash on iPad.
This was due to the action sheet not having a `sourceView` set. I set the cell address container as the source view. This change doesn't affect the iPhone app.

_This PR needs to be merged before release_

## Attachments
![image](https://user-images.githubusercontent.com/6460866/115361798-d5536980-a1b8-11eb-9b06-f3b33ab8728e.png)

Closes #34 