### PR TITLE
🎨 Add stats to display the percentage of availabilities

### DIFF
--- a/ViteMaDose/Models/Stats.swift
+++ b/ViteMaDose/Models/Stats.swift
@@ -13,6 +13,10 @@ struct StatsValue: Codable {
     let disponibles: Int
     let total: Int
     let creneaux: Int
+    
+    var pourcentage: Int {
+        (disponibles * 100) / total
+    }
 
     enum CodingKeys: String, CodingKey {
         case disponibles = "disponibles"

--- a/ViteMaDose/ViewModels/Home/HomeViewModel.swift
+++ b/ViteMaDose/ViewModels/Home/HomeViewModel.swift
@@ -125,8 +125,8 @@ class HomeViewModel {
         statsCell = [
             .title(statsTitleViewModel),
             .stats(allCentresViewModel),
-            .stats(centresWithAvailabilitiesViewModel),
             .stats(allAvailabilitiesViewModel),
+            .stats(centresWithAvailabilitiesViewModel),
             .stats(percentageAvailabilitiesViewModel),
             .stats(externalMapViewModel)
         ]

--- a/ViteMaDose/ViewModels/Home/HomeViewModel.swift
+++ b/ViteMaDose/ViewModels/Home/HomeViewModel.swift
@@ -119,6 +119,7 @@ class HomeViewModel {
         let allCentresViewModel = HomeCellStatsViewData(.allCentres(allCountiesStats.total))
         let centresWithAvailabilitiesViewModel = HomeCellStatsViewData(.centresWithAvailabilities(allCountiesStats.disponibles))
         let allAvailabilitiesViewModel = HomeCellStatsViewData(.allAvailabilities(allCountiesStats.creneaux))
+        let percentageAvailabilitiesViewModel = HomeCellStatsViewData(.percentageAvailabilities(allCountiesStats.pourcentage))
         let externalMapViewModel = HomeCellStatsViewData(.externalMap)
 
         statsCell = [
@@ -126,6 +127,7 @@ class HomeViewModel {
             .stats(allCentresViewModel),
             .stats(centresWithAvailabilitiesViewModel),
             .stats(allAvailabilitiesViewModel),
+            .stats(percentageAvailabilitiesViewModel),
             .stats(externalMapViewModel)
         ]
     }

--- a/ViteMaDose/Views/Home/Cells/HomeStatsCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeStatsCell.swift
@@ -11,6 +11,7 @@ enum StatsDataType: Hashable {
     case allCentres(Int)
     case centresWithAvailabilities(Int)
     case allAvailabilities(Int)
+    case percentageAvailabilities(Int)
     case externalMap
 }
 
@@ -90,6 +91,10 @@ struct HomeCellStatsViewData: HomeStatsCellViewDataProvider, Hashable {
             case let .allAvailabilities(count):
                 title = NSMutableAttributedString(string: String(count))
                 description = "Créneaux disponibles"
+                iconContainerColor = .royalBlue
+            case let .percentageAvailabilities(count):
+                title = NSMutableAttributedString(string: "\(count)%")
+                description = "De centres avec des disponibilités"
                 iconContainerColor = .systemBlue
             case .externalMap:
                 let imageAttachment = NSTextAttachment()
@@ -121,6 +126,8 @@ private extension StatsDataType {
                 imageName = "checkmark"
             case .allAvailabilities:
                 imageName = "calendar"
+            case .percentageAvailabilities:
+                imageName = "percent"
             case .externalMap:
                 imageName = "mappin"
         }


### PR DESCRIPTION
Fix #11 

<img width="504" alt="image" src="https://user-images.githubusercontent.com/30439790/115424968-77964000-a1ff-11eb-88e0-0173a5ad562c.png">

In comparison, this is the view on the Android version:
![image](https://user-images.githubusercontent.com/30439790/115425878-4ec27a80-a200-11eb-932f-ef6a156264d1.png)
