### PR TITLE
Integrate swift lint + fix warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+included:
+    - ViteMaDose
+    - ViteMaDosesTests
+    - ViteMaDoseUITests
+disabled_rules:
+    - large_tuple
+    - force_cast

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,3 +5,6 @@ included:
 disabled_rules:
     - large_tuple
     - force_cast
+    - todo
+    - nesting
+line_length: 200

--- a/ViteMaDose.xcodeproj/project.pbxproj
+++ b/ViteMaDose.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		57ECA226262B031F001B368F /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		57FE5C0E261FA84D0012B66D /* UIColor+VideMaDose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+VideMaDose.swift"; sourceTree = "<group>"; };
 		6A28354B262DC06C00FA6456 /* ViteMaDose.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ViteMaDose.entitlements; sourceTree = "<group>"; };
+		889B9A49263307EC00175E24 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		DA234DC22626494600D6F71C /* remote-configuration.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "remote-configuration.plist"; sourceTree = "<group>"; };
 		DA234DD02626506600D6F71C /* RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfig.swift; sourceTree = "<group>"; };
 		DA4D9952261E6B6A00D28AD0 /* CountySelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountySelectionViewController.swift; sourceTree = "<group>"; };
@@ -224,6 +225,7 @@
 		576738B3261E329C004A700D = {
 			isa = PBXGroup;
 			children = (
+				889B9A49263307EC00175E24 /* .swiftlint.yml */,
 				576738BE261E329C004A700D /* ViteMaDose */,
 				576738D5261E32A3004A700D /* ViteMaDoseTests */,
 				576738E0261E32A3004A700D /* ViteMaDoseUITests */,
@@ -493,6 +495,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 576738E6261E32A3004A700D /* Build configuration list for PBXNativeTarget "ViteMaDose" */;
 			buildPhases = (
+				889B9A48263307BC00175E24 /* Swiftlint */,
 				576738B8261E329C004A700D /* Sources */,
 				576738B9261E329C004A700D /* Frameworks */,
 				576738BA261E329C004A700D /* Resources */,
@@ -588,6 +591,7 @@
 			developmentRegion = fr;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				fr,
 				en,
 				Base,
 			);
@@ -687,6 +691,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "$SRCROOT/Scripts/set_build_number.sh\n";
+		};
+		889B9A48263307BC00175E24 /* Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Swiftlint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		DA68646626276624005B2AC2 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ViteMaDose/Helpers/Extensions/StringExtension.swift
+++ b/ViteMaDose/Helpers/Extensions/StringExtension.swift
@@ -8,19 +8,18 @@
 import Foundation
 
 extension String {
-    
+
     // Localization
-        
     func localized(bundle: Bundle = .main, tableName: String = "Localizable") -> String {
         return NSLocalizedString(self, tableName: tableName, value: "**\(self)**", comment: "")
     }
 
-    func format(_ args : CVarArg...) -> String {
+    func format(_ args: CVarArg...) -> String {
         return String(format: self, locale: .current, arguments: args)
     }
 
-    func format(_ args : [String]) -> String {
+    func format(_ args: [String]) -> String {
         return String(format: self, locale: .current, arguments: args)
     }
-    
+
 }

--- a/ViteMaDose/Helpers/Extensions/UITableView+Commons.swift
+++ b/ViteMaDose/Helpers/Extensions/UITableView+Commons.swift
@@ -13,7 +13,7 @@ extension UITableView {
         let nib = UINib(nibName: className, bundle: bundle)
         register(nib, forCellReuseIdentifier: className)
     }
-    
+
     func dequeueReusableCell<T: UITableViewCell>(with type: T.Type, for indexPath: IndexPath) -> T {
         return self.dequeueReusableCell(withIdentifier: type.className, for: indexPath) as! T
     }

--- a/ViteMaDose/Helpers/Extensions/UIViewControllerController+Commons.swift
+++ b/ViteMaDose/Helpers/Extensions/UIViewControllerController+Commons.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIViewController {
-    var embedInNavigationController:  UINavigationController {
+    var embedInNavigationController: UINavigationController {
         return UINavigationController(rootViewController: self)
     }
 }

--- a/ViteMaDose/Helpers/Extensions/URL+Commons.swift
+++ b/ViteMaDose/Helpers/Extensions/URL+Commons.swift
@@ -16,13 +16,13 @@ extension URL {
         guard var urlComponents = URLComponents(string: absoluteString) else { return absoluteURL }
         var queryItems: [URLQueryItem] = urlComponents.queryItems ?? []
         let queryItem = URLQueryItem(name: queryItem, value: value)
-        
+
         queryItems.append(queryItem)
         urlComponents.queryItems = queryItems
-        
+
         return urlComponents.url!
     }
-    
+
     /// Init an URL
     /// - Parameter string: String URL
     init(staticString string: StaticString) {

--- a/ViteMaDose/Helpers/Utils/AppAnalytics.swift
+++ b/ViteMaDose/Helpers/Utils/AppAnalytics.swift
@@ -21,7 +21,7 @@ struct AppAnalytics {
             AnalyticsEventScreenView,
             parameters: [
                 AnalyticsParameterScreenName: screenName.rawValue,
-                AnalyticsParameterScreenClass: screenClass,
+                AnalyticsParameterScreenClass: screenClass
             ])
     }
 
@@ -48,7 +48,7 @@ struct AppAnalytics {
             "rdv_name": name,
             "rdv_location_type": type,
             "rdv_platform": platform,
-            "rdv_vaccine":vaccine,
+            "rdv_vaccine": vaccine
         ])
     }
 

--- a/ViteMaDose/Models/County.swift
+++ b/ViteMaDose/Models/County.swift
@@ -14,7 +14,7 @@ struct County: Codable {
     let nomDepartement: String?
     let codeRegion: Int?
     let nomRegion: String?
-    
+
     enum CodingKeys: String, CodingKey {
         case codeDepartement = "code_departement"
         case nomDepartement = "nom_departement"

--- a/ViteMaDose/Models/PartnerLogo.swift
+++ b/ViteMaDose/Models/PartnerLogo.swift
@@ -16,33 +16,33 @@ enum PartnerLogo: String, CaseIterable {
 
     var image: UIImage? {
         switch self {
-            case .doctolib:
-                return UIImage(named: PartnerLogo.doctolib.rawValue)
-            case .maiia:
-                return UIImage(named: PartnerLogo.maiia.rawValue)
-            case .ordoclic:
-                return UIImage(named: PartnerLogo.ordoclic.rawValue)
-            case .keldoc:
-                return UIImage(named: PartnerLogo.keldoc.rawValue)
-            case .maPharma:
-                return UIImage(named: PartnerLogo.maPharma.rawValue)
+        case .doctolib:
+            return UIImage(named: PartnerLogo.doctolib.rawValue)
+        case .maiia:
+            return UIImage(named: PartnerLogo.maiia.rawValue)
+        case .ordoclic:
+            return UIImage(named: PartnerLogo.ordoclic.rawValue)
+        case .keldoc:
+            return UIImage(named: PartnerLogo.keldoc.rawValue)
+        case .maPharma:
+            return UIImage(named: PartnerLogo.maPharma.rawValue)
         }
     }
 
     init?(rawValue: String) {
         switch rawValue {
-            case PartnerLogo.doctolib.rawValue:
-                self = .doctolib
-            case PartnerLogo.maiia.rawValue:
-                self = .maiia
-            case PartnerLogo.ordoclic.rawValue:
-                self = .ordoclic
-            case PartnerLogo.keldoc.rawValue:
-                self = .keldoc
-            case PartnerLogo.maPharma.rawValue:
-                self = .maPharma
-            default:
-                return nil
+        case PartnerLogo.doctolib.rawValue:
+            self = .doctolib
+        case PartnerLogo.maiia.rawValue:
+            self = .maiia
+        case PartnerLogo.ordoclic.rawValue:
+            self = .ordoclic
+        case PartnerLogo.keldoc.rawValue:
+            self = .keldoc
+        case PartnerLogo.maPharma.rawValue:
+            self = .maPharma
+        default:
+            return nil
         }
     }
 }

--- a/ViteMaDose/Models/Stats.swift
+++ b/ViteMaDose/Models/Stats.swift
@@ -13,15 +13,15 @@ struct StatsValue: Codable {
     let disponibles: Int
     let total: Int
     let creneaux: Int
-    
+
     var pourcentage: Int {
         (disponibles * 100) / total
     }
 
     enum CodingKeys: String, CodingKey {
-        case disponibles = "disponibles"
-        case total = "total"
-        case creneaux = "creneaux"
+        case disponibles
+        case total
+        case creneaux
     }
 }
 
@@ -31,10 +31,10 @@ enum StatsKey {
 
     var rawValue: String {
         switch self {
-            case .allCounties:
-                return "tout_departement"
-            case let .county(code):
-                return String(code)
+        case .allCounties:
+            return "tout_departement"
+        case let .county(code):
+            return String(code)
         }
     }
 }

--- a/ViteMaDose/Models/VaccinationCentre.swift
+++ b/ViteMaDose/Models/VaccinationCentre.swift
@@ -42,9 +42,9 @@ extension VaccinationCentre {
         let city: String?
 
         enum CodingKeys: String, CodingKey {
-            case longitude = "longitude"
-            case latitude = "latitude"
-            case city = "city"
+            case longitude
+            case latitude
+            case city
         }
     }
 
@@ -54,13 +54,12 @@ extension VaccinationCentre {
         let businessHours: [String: String?]?
 
         enum CodingKeys: String, CodingKey {
-            case address = "address"
+            case address
             case phoneNumber = "phone_number"
             case businessHours = "business_hours"
         }
     }
 }
-
 
 // MARK: - VaccinationCentres
 
@@ -68,7 +67,7 @@ struct VaccinationCentres: Codable {
     let lastUpdated: String?
     let centresDisponibles: [VaccinationCentre]
     let centresIndisponibles: [VaccinationCentre]
-    
+
     enum CodingKeys: String, CodingKey {
         case lastUpdated = "last_updated"
         case centresDisponibles = "centres_disponibles"

--- a/ViteMaDose/Networking/APIService.swift
+++ b/ViteMaDose/Networking/APIService.swift
@@ -10,16 +10,16 @@ import APIRequest
 
 protocol APIServiceProvider {
     @discardableResult
-    func fetchCounties(completion: @escaping (Counties?, APIResponseStatus) -> ()) -> APIRequest
+    func fetchCounties(completion: @escaping (Counties?, APIResponseStatus) -> Void) -> APIRequest
     @discardableResult
-    func fetchVaccinationCentres(country: String, completion: @escaping (VaccinationCentres?, APIResponseStatus) -> ()) -> APIRequest
+    func fetchVaccinationCentres(country: String, completion: @escaping (VaccinationCentres?, APIResponseStatus) -> Void) -> APIRequest
     @discardableResult
-    func fetchStats(completion: @escaping (Stats?, APIResponseStatus) -> ()) -> APIRequest
+    func fetchStats(completion: @escaping (Stats?, APIResponseStatus) -> Void) -> APIRequest
 }
 
 struct APIService: APIServiceProvider {
 
-    func fetchCounties(completion: @escaping (Counties?, APIResponseStatus) -> ()) -> APIRequest {
+    func fetchCounties(completion: @escaping (Counties?, APIResponseStatus) -> Void) -> APIRequest {
         let configuration = APIConfiguration(host: RemoteConfiguration.shared.host)
         return APIRequest(
             "GET",
@@ -32,7 +32,7 @@ struct APIService: APIServiceProvider {
         }
     }
 
-    func fetchVaccinationCentres(country: String, completion: @escaping (VaccinationCentres?, APIResponseStatus) -> ()) -> APIRequest {
+    func fetchVaccinationCentres(country: String, completion: @escaping (VaccinationCentres?, APIResponseStatus) -> Void) -> APIRequest {
         let configuration = APIConfiguration(host: RemoteConfiguration.shared.host)
         return APIRequest(
             "GET",
@@ -45,7 +45,7 @@ struct APIService: APIServiceProvider {
         }
     }
 
-    func fetchStats(completion: @escaping (Stats?, APIResponseStatus) -> ()) -> APIRequest {
+    func fetchStats(completion: @escaping (Stats?, APIResponseStatus) -> Void) -> APIRequest {
         let configuration = APIConfiguration(host: RemoteConfiguration.shared.host)
         return APIRequest(
             "GET",
@@ -61,16 +61,14 @@ struct APIService: APIServiceProvider {
 }
 
 extension APIResponseStatus: LocalizedError {
-    
     public var errorDescription: String? {
         switch self {
-            case .error:
-                return "Nous rencontrons des problèmes avec le serveur, veuillez réessayer plus tard."
-            case .offline:
-                return "Il semblerait que vous soyez hors ligne."
-            default:
-                return "Une erreur est survenue, veuillez réessayer plus tard."
+        case .error:
+            return "Nous rencontrons des problèmes avec le serveur, veuillez réessayer plus tard."
+        case .offline:
+            return "Il semblerait que vous soyez hors ligne."
+        default:
+            return "Une erreur est survenue, veuillez réessayer plus tard."
         }
     }
-    
 }

--- a/ViteMaDose/Networking/RemoteConfig.swift
+++ b/ViteMaDose/Networking/RemoteConfig.swift
@@ -10,7 +10,7 @@ import FirebaseRemoteConfig
 import APIRequest
 
 struct RemoteConfiguration {
-    
+
     static let shared = RemoteConfiguration()
     let configuration: RemoteConfig
 
@@ -23,8 +23,8 @@ struct RemoteConfiguration {
         configuration.configSettings = settings
     }
 
-    func synchronize(completion: @escaping (APIResponseStatus) -> ()) {
-        configuration.fetch(withExpirationDuration: 0) { (status, error) in
+    func synchronize(completion: @escaping (APIResponseStatus) -> Void) {
+        configuration.fetch(withExpirationDuration: 0) { (_, error) in
             guard error == nil else {
                 print("Error while fetching remote configuration (\(error.debugDescription)).")
                 completion(.error)
@@ -44,7 +44,7 @@ extension RemoteConfiguration {
     var host: String {
         return baseUrl.replacingOccurrences(of: "https://", with: "")
     }
-    
+
     var baseUrl: String {
         return configuration.configValue(forKey: "url_base").stringValue!
     }

--- a/ViteMaDose/SceneDelegate.swift
+++ b/ViteMaDose/SceneDelegate.swift
@@ -11,12 +11,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        // swiftlint:disable unused_optional_binding
         guard let _ = (scene as? UIWindowScene) else { return }
+        // swiftlint:enable unused_optional_binding
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -46,7 +47,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
+++ b/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
@@ -124,7 +124,7 @@ class CentresListViewModel {
 
         headingCells = [
             .title(mainTitleViewData),
-            .stats(statsCellViewData),
+            .stats(statsCellViewData)
         ]
 
         guard !isEmpty else {
@@ -154,7 +154,6 @@ class CentresListViewModel {
         let lastUpdateTime = lastUpdate.toString(.time(.short))
         footerText = "Dernière mise à jour le \(lastUpdateDay) à \(lastUpdateTime)"
     }
-
 
     func getVaccinationCentreViewData(_ centre: VaccinationCentre) -> CentreViewData {
         var url: URL?
@@ -191,8 +190,7 @@ class CentresListViewModel {
                     ignoreType: true
                 )
                 phoneText = phoneNumberKit.format(parsedPhoneNumber, toType: .national)
-            }
-            catch {
+            } catch {
                 phoneText = phoneNumber
             }
         }
@@ -251,7 +249,7 @@ extension CentresListViewModel: CentresListViewModelProvider {
         else {
             return nil
         }
-        return (name, centre.metadata?.address, lat,  long)
+        return (name, centre.metadata?.address, lat, long)
     }
 
     func phoneNumberLink(at indexPath: IndexPath) -> URL? {

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -62,7 +62,7 @@ class CentreCell: UITableViewCell {
         dateIconContainer,
         addressNameIconContainer,
         phoneNumberIconContainer,
-        vaccineTypesIconContainer,
+        vaccineTypesIconContainer
     ]
 
     var addressTapHandler: (() -> Void)?
@@ -156,7 +156,7 @@ class CentreCell: UITableViewCell {
     ) -> NSMutableAttributedString {
         let attributes = [
             NSAttributedString.Key.foregroundColor: Constant.labelPrimaryColor,
-            NSAttributedString.Key.font: Constant.labelPrimaryFont,
+            NSAttributedString.Key.font: Constant.labelPrimaryFont
         ]
 
         guard isAvailable else {
@@ -191,7 +191,7 @@ class CentreCell: UITableViewCell {
     ) {
         let attributes = [
             NSAttributedString.Key.font: Constant.dosesLabelFont,
-            NSAttributedString.Key.foregroundColor: Constant.labelSecondaryColor,
+            NSAttributedString.Key.foregroundColor: Constant.labelSecondaryColor
         ]
 
         guard let dosesCount = dosesCount, dosesCount > 0 else {
@@ -226,9 +226,9 @@ class CentreCell: UITableViewCell {
         let phoneButtonAttributedText = NSMutableAttributedString(
             string: phoneNumber,
             attributes: [
-                NSAttributedString.Key.foregroundColor : Constant.labelPrimaryColor,
-                NSAttributedString.Key.font : Constant.labelPrimaryFont,
-                NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
+                NSAttributedString.Key.foregroundColor: Constant.labelPrimaryColor,
+                NSAttributedString.Key.font: Constant.labelPrimaryFont,
+                NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue
             ]
         )
 
@@ -252,8 +252,8 @@ class CentreCell: UITableViewCell {
         let bookingButtonAttributedText = NSMutableAttributedString(
             string: viewData.bookingButtonText,
             attributes: [
-                NSAttributedString.Key.foregroundColor : UIColor.white,
-                NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15, weight: .semibold),
+                NSAttributedString.Key.foregroundColor: UIColor.white,
+                NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .semibold)
             ]
         )
 
@@ -270,10 +270,10 @@ class CentreCell: UITableViewCell {
     }
 
     private func setCornerRadius(to radius: CGFloat, for views: [UIView]) {
-        views.forEach{ $0.setCornerRadius(radius) }
+        views.forEach { $0.setCornerRadius(radius) }
     }
 
     private func resetTextFor(_ labels: [UILabel]) {
-        labels.forEach{ $0.text = nil }
+        labels.forEach { $0.text = nil }
     }
 }

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
@@ -255,7 +255,7 @@
         <image name="calendar" catalog="system" width="128" height="106"/>
         <image name="location.fill" catalog="system" width="128" height="121"/>
         <image name="phone.fill" catalog="system" width="128" height="114"/>
-        <image name="shippingbox.fill" catalog="system" width="128" height="124"/>
+        <image name="cube.box.fill" catalog="system" width="128" height="124"/>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
@@ -157,7 +157,7 @@
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="unG-8S-bvw">
                                                         <rect key="frame" x="4" y="4.3333333333333339" width="17" height="17"/>
                                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <imageReference key="image" image="cube.box.fill" catalog="system" symbolScale="default"/>
+                                                        <imageReference key="image" image="shippingbox.fill" catalog="system" symbolScale="default"/>
                                                     </imageView>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemPurpleColor"/>
@@ -253,9 +253,9 @@
     </objects>
     <resources>
         <image name="calendar" catalog="system" width="128" height="106"/>
-        <image name="cube.box.fill" catalog="system" width="128" height="124"/>
         <image name="location.fill" catalog="system" width="128" height="121"/>
         <image name="phone.fill" catalog="system" width="128" height="114"/>
+        <image name="shippingbox.fill" catalog="system" width="128" height="124"/>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
@@ -157,7 +157,7 @@
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="unG-8S-bvw">
                                                         <rect key="frame" x="4" y="4.3333333333333339" width="17" height="17"/>
                                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <imageReference key="image" image="shippingbox.fill" catalog="system" symbolScale="default"/>
+                                                        <imageReference key="image" image="cube.box.fill" catalog="system" symbolScale="default"/>
                                                     </imageView>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemPurpleColor"/>

--- a/ViteMaDose/Views/CentresList/Cells/CentresTitleCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentresTitleCell.swift
@@ -31,12 +31,12 @@ extension CentresTitleCell {
     ) -> NSMutableAttributedString {
         let attributes = [
             NSAttributedString.Key.foregroundColor: Constant.titleColor,
-            NSAttributedString.Key.font: Constant.titleFont,
+            NSAttributedString.Key.font: Constant.titleFont
         ]
 
         guard dosesCount > 0 else {
             let title = NSMutableAttributedString(
-                string:"\(Constant.titleNoDoseText) \(countyName)",
+                string: "\(Constant.titleNoDoseText) \(countyName)",
                 attributes: attributes
             )
             title.setColorForText(textForAttribute: countyName, withColor: .mandy)
@@ -58,7 +58,7 @@ extension CentresTitleCell {
     static var centresListTitle: NSMutableAttributedString {
         let attributes = [
             NSAttributedString.Key.foregroundColor: Constant.titleColor,
-            NSAttributedString.Key.font: Constant.titleFont,
+            NSAttributedString.Key.font: Constant.titleFont
         ]
         return NSMutableAttributedString(string: Constant.subtitleText, attributes: attributes)
     }

--- a/ViteMaDose/Views/CentresList/CentresListViewController.swift
+++ b/ViteMaDose/Views/CentresList/CentresListViewController.swift
@@ -153,7 +153,7 @@ extension CentresListViewController: CentresListViewModelDelegate {
 
     func updateLoadingState(isLoading: Bool, isEmpty: Bool) {
         tableView.tableFooterView?.isHidden = isLoading
-        
+
         if !isLoading {
             activityIndicator.stopAnimating()
             refreshControl.endRefreshing()
@@ -194,7 +194,7 @@ extension CentresListViewController {
     private func makeDataSource() -> UITableViewDiffableDataSource<CentresListSection, CentresListCell> {
         return UITableViewDiffableDataSource(
             tableView: tableView,
-            cellProvider: { [weak self] tableView, indexPath, vaccinationCentreCell in
+            cellProvider: { [weak self] _, indexPath, vaccinationCentreCell in
                 return self?.dequeueAndConfigure(cell: vaccinationCentreCell, at: indexPath)
             }
         )
@@ -202,19 +202,19 @@ extension CentresListViewController {
 
     private func dequeueAndConfigure(cell: CentresListCell, at indexPath: IndexPath) -> UITableViewCell {
         switch cell {
-            case let .title(cellViewData):
-                let cell = tableView.dequeueReusableCell(with: CentresTitleCell.self, for: indexPath)
-                cell.configure(with: cellViewData)
-                return cell
-            case let .stats(cellViewData):
-                let cell = tableView.dequeueReusableCell(with: CentresStatsCell.self, for: indexPath)
-                cell.configure(with: cellViewData)
-                return cell
-            case let .centre(cellViewData):
-                let cell = tableView.dequeueReusableCell(with: CentreCell.self, for: indexPath)
-                configureHandlers(for: cell, at: indexPath)
-                cell.configure(with: cellViewData)
-                return cell
+        case let .title(cellViewData):
+            let cell = tableView.dequeueReusableCell(with: CentresTitleCell.self, for: indexPath)
+            cell.configure(with: cellViewData)
+            return cell
+        case let .stats(cellViewData):
+            let cell = tableView.dequeueReusableCell(with: CentresStatsCell.self, for: indexPath)
+            cell.configure(with: cellViewData)
+            return cell
+        case let .centre(cellViewData):
+            let cell = tableView.dequeueReusableCell(with: CentreCell.self, for: indexPath)
+            configureHandlers(for: cell, at: indexPath)
+            cell.configure(with: cellViewData)
+            return cell
         }
     }
 
@@ -262,7 +262,7 @@ extension CentresListViewController {
             MKMapItem.openMaps(
                 with: [mapItem],
                 launchOptions: [
-                    MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDefault,
+                    MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDefault
                 ]
             )
         }
@@ -277,7 +277,6 @@ extension CentresListViewController {
         present(actionSheet, animated: true)
     }
 }
-
 
 extension CentresListViewController: UIGestureRecognizerDelegate {
 

--- a/ViteMaDose/Views/CountySelection/CountySelectionViewController.swift
+++ b/ViteMaDose/Views/CountySelection/CountySelectionViewController.swift
@@ -54,14 +54,14 @@ extension CountySelectionViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         viewModel.numberOfRows
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(with: CountyCell.self, for: indexPath)
         guard let cellViewModel = viewModel.cellViewModel(at: indexPath) else {
             assertionFailure("Cell view model missing at \(indexPath)")
             return UITableViewCell()
         }
-        
+
         cell.configure(with: cellViewModel)
         return cell
     }
@@ -87,4 +87,3 @@ extension CountySelectionViewController: CountySelectionViewModelDelegate {
         }
     }
 }
-

--- a/ViteMaDose/Views/CountySelection/Header/CountySelectionHeaderView.swift
+++ b/ViteMaDose/Views/CountySelection/Header/CountySelectionHeaderView.swift
@@ -30,7 +30,7 @@ class CountySelectionHeaderView: UIView {
             string: Constant.titleText,
             attributes: [
                 NSAttributedString.Key.font: Constant.titleFont,
-                NSAttributedString.Key.foregroundColor: UIColor.label,
+                NSAttributedString.Key.foregroundColor: UIColor.label
             ]
         )
         attributedText.setColorForText(

--- a/ViteMaDose/Views/Home/Cells/HomeCountySelectionCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeCountySelectionCell.swift
@@ -16,7 +16,7 @@ struct HomeCountySelectionViewData: HomeCountySelectionCellViewDataProvider, Has
 }
 
 class HomeCountySelectionCell: UITableViewCell {
-    
+
     @IBOutlet private var searchBarView: UIView!
     @IBOutlet private var searchBarTitle: UILabel!
 
@@ -32,7 +32,6 @@ class HomeCountySelectionCell: UITableViewCell {
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         searchBarView.backgroundColor = .tertiarySystemBackground
-
 
         searchBarTitle.font = Constant.searchBarFont
 

--- a/ViteMaDose/Views/Home/Cells/HomeStatsCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeStatsCell.swift
@@ -79,38 +79,37 @@ struct HomeCellStatsViewData: HomeStatsCellViewDataProvider, Hashable {
         icon = dataType.iconImage
 
         switch dataType {
-            case let .allCentres(count):
-                title = NSMutableAttributedString(string: String(count))
-                description = "Centres trouvés en France"
-                iconContainerColor = .systemOrange
-            case let .centresWithAvailabilities(count):
-                title = NSMutableAttributedString(string: String(count))
-                // TODO: Localisation
-                description = "\(count > 1 ? "Centres" : "Centre") avec rendez-vous disponibles"
-                iconContainerColor = .systemGreen
-            case let .allAvailabilities(count):
-                title = NSMutableAttributedString(string: String(count))
-                description = "Créneaux disponibles"
-                iconContainerColor = .royalBlue
-            case let .percentageAvailabilities(count):
-                title = NSMutableAttributedString(string: "\(count)%")
-                description = "De centres avec des disponibilités"
-                iconContainerColor = .systemBlue
-            case .externalMap:
-                let imageAttachment = NSTextAttachment()
-                imageAttachment.image = UIImage(
-                    systemName: "arrow.up.right",
-                    withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
-                )?.withTintColor(.label, renderingMode: .alwaysOriginal)
+        case let .allCentres(count):
+            title = NSMutableAttributedString(string: String(count))
+            description = "Centres trouvés en France"
+            iconContainerColor = .systemOrange
+        case let .centresWithAvailabilities(count):
+            title = NSMutableAttributedString(string: String(count))
+            // TODO: Localisation
+            description = "\(count > 1 ? "Centres" : "Centre") avec rendez-vous disponibles"
+            iconContainerColor = .systemGreen
+        case let .allAvailabilities(count):
+            title = NSMutableAttributedString(string: String(count))
+            description = "Créneaux disponibles"
+            iconContainerColor = .royalBlue
+        case let .percentageAvailabilities(count):
+            title = NSMutableAttributedString(string: "\(count)%")
+            description = "De centres avec des disponibilités"
+            iconContainerColor = .systemBlue
+        case .externalMap:
+            let imageAttachment = NSTextAttachment()
+            imageAttachment.image = UIImage(
+                systemName: "arrow.up.right",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
+            )?.withTintColor(.label, renderingMode: .alwaysOriginal)
 
-                let fullString = NSMutableAttributedString(string: "Ouvrir la carte des centres ")
-                fullString.append(NSAttributedString(attachment: imageAttachment))
-                title = fullString
-                description = nil
-                iconContainerColor = .systemRed
+            let fullString = NSMutableAttributedString(string: "Ouvrir la carte des centres ")
+            fullString.append(NSAttributedString(attachment: imageAttachment))
+            title = fullString
+            description = nil
+            iconContainerColor = .systemRed
         }
     }
-
 }
 
 private extension StatsDataType {
@@ -120,16 +119,16 @@ private extension StatsDataType {
         let configuration = UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
 
         switch self {
-            case .allCentres:
-                imageName = "magnifyingglass"
-            case .centresWithAvailabilities:
-                imageName = "checkmark"
-            case .allAvailabilities:
-                imageName = "calendar"
-            case .percentageAvailabilities:
-                imageName = "percent"
-            case .externalMap:
-                imageName = "mappin"
+        case .allCentres:
+            imageName = "magnifyingglass"
+        case .centresWithAvailabilities:
+            imageName = "checkmark"
+        case .allAvailabilities:
+            imageName = "calendar"
+        case .percentageAvailabilities:
+            imageName = "percent"
+        case .externalMap:
+            imageName = "mappin"
         }
 
         let image = UIImage(systemName: imageName, withConfiguration: configuration)

--- a/ViteMaDose/Views/Home/Cells/HomeTitleCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeTitleCell.swift
@@ -69,7 +69,7 @@ extension HomeTitleCell {
             string: titleText,
             attributes: [
                 NSAttributedString.Key.font: titleFont,
-                NSAttributedString.Key.foregroundColor: UIColor.label,
+                NSAttributedString.Key.foregroundColor: UIColor.label
             ]
         )
 
@@ -93,7 +93,7 @@ extension HomeTitleCell {
             string: titleText,
             attributes: [
                 NSAttributedString.Key.font: titleFont,
-                NSAttributedString.Key.foregroundColor: UIColor.label,
+                NSAttributedString.Key.foregroundColor: UIColor.label
             ]
         )
     }

--- a/ViteMaDose/Views/Home/Footer/HomePartnersFooterView.swift
+++ b/ViteMaDose/Views/Home/Footer/HomePartnersFooterView.swift
@@ -25,13 +25,13 @@ class HomePartnersFooterView: UIView {
         logo2ImageView,
         logo3ImageView,
         logo4ImageView,
-        logoImageView5,
+        logoImageView5
     ]
 
     override func awakeFromNib() {
         super.awakeFromNib()
         backgroundColor = .athensGray
-        
+
         titleLabel.text = Constant.titleText
         titleLabel.font = .systemFont(ofSize: 13, weight: .light)
         titleLabel.textColor = .secondaryLabel

--- a/ViteMaDose/Views/Home/HomeViewController.swift
+++ b/ViteMaDose/Views/Home/HomeViewController.swift
@@ -213,18 +213,18 @@ extension HomeViewController: UITableViewDelegate {
         }
 
         switch homeCell {
-            case .countySelection:
-                presentCountySelectionViewController()
-            case .county:
-                viewModel.didSelectLastCounty()
-                Haptic.impact(.light).generate()
-            case let .stats(viewData):
-                guard viewData.dataType == .externalMap else {
-                    return
-                }
-                presentVaccinationCentresMap()
-            default:
+        case .countySelection:
+            presentCountySelectionViewController()
+        case .county:
+            viewModel.didSelectLastCounty()
+            Haptic.impact(.light).generate()
+        case let .stats(viewData):
+            guard viewData.dataType == .externalMap else {
                 return
+            }
+            presentVaccinationCentresMap()
+        default:
+            return
         }
     }
 }
@@ -236,7 +236,7 @@ extension HomeViewController {
     private func makeDataSource() -> UITableViewDiffableDataSource<HomeSection, HomeCell> {
         return UITableViewDiffableDataSource(
             tableView: tableView,
-            cellProvider: { [weak self] tableView, indexPath, homeCell in
+            cellProvider: { [weak self] _, indexPath, homeCell in
                 return self?.dequeueAndConfigure(cell: homeCell, at: indexPath)
             }
         )
@@ -244,22 +244,22 @@ extension HomeViewController {
 
     private func dequeueAndConfigure(cell: HomeCell, at indexPath: IndexPath) -> UITableViewCell {
         switch cell {
-            case let .title(cellViewModel):
-                let cell = tableView.dequeueReusableCell(with: HomeTitleCell.self, for: indexPath)
-                cell.configure(with: cellViewModel)
-                return cell
-            case let .countySelection(cellViewModel):
-                let cell = tableView.dequeueReusableCell(with: HomeCountySelectionCell.self, for: indexPath)
-                cell.configure(with: cellViewModel)
-                return cell
-            case let .county(cellViewModel):
-                let cell = tableView.dequeueReusableCell(with: HomeCountyCell.self, for: indexPath)
-                cell.configure(with: cellViewModel)
-                return cell
-            case let .stats(cellViewModel):
-                let cell = tableView.dequeueReusableCell(with: HomeStatsCell.self, for: indexPath)
-                cell.configure(with: cellViewModel)
-                return cell
+        case let .title(cellViewModel):
+            let cell = tableView.dequeueReusableCell(with: HomeTitleCell.self, for: indexPath)
+            cell.configure(with: cellViewModel)
+            return cell
+        case let .countySelection(cellViewModel):
+            let cell = tableView.dequeueReusableCell(with: HomeCountySelectionCell.self, for: indexPath)
+            cell.configure(with: cellViewModel)
+            return cell
+        case let .county(cellViewModel):
+            let cell = tableView.dequeueReusableCell(with: HomeCountyCell.self, for: indexPath)
+            cell.configure(with: cellViewModel)
+            return cell
+        case let .stats(cellViewModel):
+            let cell = tableView.dequeueReusableCell(with: HomeStatsCell.self, for: indexPath)
+            cell.configure(with: cellViewModel)
+            return cell
         }
     }
 }


### PR DESCRIPTION
I integrated `swiftlint` to the project. I disabled all rules that immedialty produced an error : 

- large_tuple
- force_cast
- todo
- nesting
- lin_length configured bigger as default

Then I fixed all the warnings related to `swiftlint` + one more regaring one deprecated SFSymbol image name