### PR TITLE
Fix - Reload stats crash on Home

### DIFF
--- a/ViteMaDose/ViewModels/Home/HomeViewModel.swift
+++ b/ViteMaDose/ViewModels/Home/HomeViewModel.swift
@@ -42,9 +42,7 @@ protocol HomeViewModelDelegate: class {
     func presentInitialLoadError(_ error: Error)
     func presentFetchStatsError(_ error: Error)
 
-    func reloadTableView(with headingCells: [HomeCell], andStatsCells: [HomeCell])
-    func reloadHeadingSection(with headingCells: [HomeCell])
-    func reloadStatsSection(with statsCells: [HomeCell])
+    func reloadTableView(with headingCells: [HomeCell], andStatsCells statsCells: [HomeCell])
 }
 
 class HomeViewModel {
@@ -87,12 +85,12 @@ class HomeViewModel {
     private func handleStatsReload(with stats: Stats) {
         self.stats = stats
         updateStatsCells()
-        delegate?.reloadStatsSection(with: statsCell)
+        delegate?.reloadTableView(with: headingCells, andStatsCells: statsCell)
     }
 
     private func handleLastSelectedCountyUpdate() {
         updateHeadingCells()
-        delegate?.reloadHeadingSection(with: headingCells)
+        delegate?.reloadTableView(with: headingCells, andStatsCells: statsCell)
     }
 
     private func updateHeadingCells() {

--- a/ViteMaDose/Views/Home/HomeViewController.swift
+++ b/ViteMaDose/Views/Home/HomeViewController.swift
@@ -119,40 +119,14 @@ extension HomeViewController: HomeViewModelDelegate {
 
     // MARK: Table View Updates
 
-    func reloadTableView(with headingCells: [HomeCell], andStatsCells: [HomeCell]) {
-        var snapshot = dataSource.snapshot()
+    func reloadTableView(with headingCells: [HomeCell], andStatsCells statsCells: [HomeCell]) {
+        var snapshot = Snapshot()
         snapshot.appendSections(HomeSection.allCases)
         snapshot.appendItems(headingCells, toSection: .heading)
-        snapshot.appendItems(andStatsCells, toSection: .stats)
+        snapshot.appendItems(statsCells, toSection: .stats)
 
         dataSource.defaultRowAnimation = .fade
         dataSource.apply(snapshot, animatingDifferences: false)
-    }
-
-    func reloadHeadingSection(with headingCells: [HomeCell]) {
-        let snapshot = dataSource.snapshot()
-
-        // Create a new snapshot with current stats cells
-        // Apply heading changes
-        var update = Snapshot()
-        update.appendSections(HomeSection.allCases)
-        update.appendItems(snapshot.itemIdentifiers(inSection: .stats), toSection: .stats)
-        update.appendItems(headingCells, toSection: .heading)
-
-        dataSource.apply(update, animatingDifferences: true)
-    }
-
-    func reloadStatsSection(with statsCells: [HomeCell]) {
-        let snapshot = dataSource.snapshot()
-
-        // Create a new snapshot with current heading cells
-        // Apply stats changes
-        var update = Snapshot()
-        update.appendSections(HomeSection.allCases)
-        update.appendItems(snapshot.itemIdentifiers(inSection: .heading), toSection: .heading)
-        update.appendItems(statsCells, toSection: .stats)
-
-        dataSource.apply(update, animatingDifferences: true)
     }
 
     // MARK: Present


### PR DESCRIPTION
## Description
We only have one crash so far on Crashlytics (🎉 ) but should address it in the next release!
The crash sometimes occurs when reloading stats on the home page (pull to refresh action).
It's really hard to reproduce and my guess it that some people tried to reload a few times in row with a dodgy connexion.

The fix is quite straight forward, I simplified the logic to reload the home sections after an update. It's now always reusing the same `reloadTableView(with headingCells: [HomeCell], andStatsCells statsCells: [HomeCell])` delegate method. This method was proven robust enough I think 😃.

It seems like using `appendItems(snapshot.itemIdentifiers(inSection: .heading), toSection: .heading)` to recreate the snapshot heading section isn't safe enough.

Again, I'll add tests soon but for now, I manually tested a lot of different scenarios and couldn't find any issue with the fix.

Closes #74 