### PR TITLE
Feature - Maintenance mode

### DIFF
--- a/ViteMaDose.xcodeproj/project.pbxproj
+++ b/ViteMaDose.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		57AF5055262CE28E0085E3C1 /* CentresTitleCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57AF5054262CE28E0085E3C1 /* CentresTitleCell.xib */; };
 		57B2BCA02633AC5B001B3D61 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B2BC9F2633AC5B001B3D61 /* Localization.swift */; };
 		57B2BCA32633B254001B3D61 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 57B2BCA52633B254001B3D61 /* Localizable.strings */; };
+		57B6BEA42636060200D9AAC1 /* MaintenanceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B6BEA32636060200D9AAC1 /* MaintenanceViewController.swift */; };
+		57B6BEAA2636153000D9AAC1 /* maintenance.html in Resources */ = {isa = PBXBuildFile; fileRef = 57B6BEA92636153000D9AAC1 /* maintenance.html */; };
 		57B7CD50262E28460065DD80 /* Haptica in Frameworks */ = {isa = PBXBuildFile; productRef = 57B7CD4F262E28460065DD80 /* Haptica */; };
 		57C38B602627826B00FE63B0 /* NSTextAttachment+Commons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C38B5F2627826B00FE63B0 /* NSTextAttachment+Commons.swift */; };
 		57C4017626235B6200EFFCA3 /* HomePartnersFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C4017426235B6200EFFCA3 /* HomePartnersFooterView.swift */; };
@@ -167,6 +169,8 @@
 		57AF5054262CE28E0085E3C1 /* CentresTitleCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CentresTitleCell.xib; sourceTree = "<group>"; };
 		57B2BC9F2633AC5B001B3D61 /* Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
 		57B2BCA42633B254001B3D61 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		57B6BEA32636060200D9AAC1 /* MaintenanceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceViewController.swift; sourceTree = "<group>"; };
+		57B6BEA92636153000D9AAC1 /* maintenance.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = maintenance.html; sourceTree = "<group>"; };
 		57C38B5F2627826B00FE63B0 /* NSTextAttachment+Commons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextAttachment+Commons.swift"; sourceTree = "<group>"; };
 		57C4017426235B6200EFFCA3 /* HomePartnersFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePartnersFooterView.swift; sourceTree = "<group>"; };
 		57C4017526235B6200EFFCA3 /* HomePartnersFooterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomePartnersFooterView.xib; sourceTree = "<group>"; };
@@ -324,6 +328,7 @@
 				5767392E261E3BB2004A700D /* Home */,
 				57AD21E22621067D00ED2B95 /* CountySelection */,
 				57AD21D4262103F000ED2B95 /* CentresList */,
+				57B6BEA2263605DE00D9AAC1 /* Maintenance */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -361,6 +366,7 @@
 			isa = PBXGroup;
 			children = (
 				576738C8261E32A2004A700D /* Assets.xcassets */,
+				57B6BEA92636153000D9AAC1 /* maintenance.html */,
 				57DEAA1826346FA7005E8628 /* Localization */,
 			);
 			path = Resources;
@@ -461,6 +467,14 @@
 				57AD21F52621097A00ED2B95 /* CentresListViewModel.swift */,
 			);
 			path = CentresList;
+			sourceTree = "<group>";
+		};
+		57B6BEA2263605DE00D9AAC1 /* Maintenance */ = {
+			isa = PBXGroup;
+			children = (
+				57B6BEA32636060200D9AAC1 /* MaintenanceViewController.swift */,
+			);
+			path = Maintenance;
 			sourceTree = "<group>";
 		};
 		57C4018526238E2200EFFCA3 /* Header */ = {
@@ -647,6 +661,7 @@
 			files = (
 				57AD21DE2621042700ED2B95 /* CentresListViewController.storyboard in Resources */,
 				5747142B262B6BA300535DF1 /* CountyCell.xib in Resources */,
+				57B6BEAA2636153000D9AAC1 /* maintenance.html in Resources */,
 				57C4018F26238E5300EFFCA3 /* CountySelectionHeaderView.xib in Resources */,
 				57C4017726235B6200EFFCA3 /* HomePartnersFooterView.xib in Resources */,
 				57673938261E3BDE004A700D /* HomeViewController.storyboard in Resources */,
@@ -783,6 +798,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				57B6BEA42636060200D9AAC1 /* MaintenanceViewController.swift in Sources */,
 				576738FB261E374A004A700D /* URL+Commons.swift in Sources */,
 				57613F03262510D700AB6F2F /* PartnerLogo.swift in Sources */,
 				575CC22F262AF4E1008D1869 /* HomeCountySelectionCell.swift in Sources */,

--- a/ViteMaDose/Networking/RemoteConfig.swift
+++ b/ViteMaDose/Networking/RemoteConfig.swift
@@ -57,8 +57,17 @@ extension RemoteConfiguration {
         return configuration.configValue(forKey: "path_list_departments").stringValue!
     }
 
+    var maintenanceModeUrl: String? {
+        let configValue = configuration.configValue(forKey: "ios_maintenance_mode_url").stringValue ?? ""
+        guard !configValue.isEmpty else {
+            return nil
+        }
+        return configValue
+    }
+
     func countyDataPath(for county: String) -> String {
         let path = configuration.configValue(forKey: "path_data_department").stringValue!
         return path.replacingOccurrences(of: "{code}", with: county)
     }
+
 }

--- a/ViteMaDose/Networking/RemoteConfig.swift
+++ b/ViteMaDose/Networking/RemoteConfig.swift
@@ -57,11 +57,12 @@ extension RemoteConfiguration {
     }
 
     var maintenanceModeUrl: String? {
-        let configValue = configuration.configValue(forKey: "ios_maintenance_mode_url").stringValue ?? ""
-        guard !configValue.isEmpty else {
+        let configValue = configuration.configValue(forKey: "ios_maintenance_mode_url").stringValue
+        if let value = configValue, !value.isEmpty {
+            return configValue
+        } else {
             return nil
         }
-        return configValue
     }
 
     func countyDataPath(for county: String) -> String {

--- a/ViteMaDose/Networking/RemoteConfig.swift
+++ b/ViteMaDose/Networking/RemoteConfig.swift
@@ -23,17 +23,16 @@ struct RemoteConfiguration {
         configuration.configSettings = settings
     }
 
-    func synchronize(completion: @escaping (APIResponseStatus) -> Void) {
-        configuration.fetch(withExpirationDuration: 0) { (_, error) in
-            guard error == nil else {
-                print("Error while fetching remote configuration (\(error.debugDescription)).")
-                completion(.error)
-                return
+    func synchronize(completion: @escaping (Result<Void, Error>) -> Void) {
+        configuration.fetch(withExpirationDuration: 0) { _, error in
+            if let error = error {
+                print("Error while fetching remote configuration (\(error.localizedDescription)).")
+                completion(.failure(error))
+            } else {
+                configuration.activate()
+                print("[RemoteConfiguration] Successfully fetched remote configuration.")
+                completion(.success(()))
             }
-
-            configuration.activate()
-            print("[RemoteConfiguration] Successfully fetched remote configuration.")
-            completion(.ok)
         }
     }
 }

--- a/ViteMaDose/Resources/maintenance.html
+++ b/ViteMaDose/Resources/maintenance.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="UTF-8">
+<title>Site Maintenance</title>
+<style>
+    body { text-align: center; padding: 150px; }
+    h1 { font-size: 50px; }
+    body { font: 20px Helvetica, sans-serif; color: #333; }
+    article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+    a { color: #dc8100; text-decoration: none; }
+    a:hover { color: #333; text-decoration: none; }
+    </style>
+
+<article>
+    <h1>Nous revenons très vite !</h1>
+    <div>
+        <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. If you need to you can always <a href="mailto:#">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
+        <p>&mdash; The Team</p>
+    </div>
+</article>

--- a/ViteMaDose/Resources/maintenance.html
+++ b/ViteMaDose/Resources/maintenance.html
@@ -1,19 +1,26 @@
 <!doctype html>
-<meta charset="UTF-8">
-<title>Site Maintenance</title>
-<style>
-    body { text-align: center; padding: 150px; }
-    h1 { font-size: 50px; }
-    body { font: 20px Helvetica, sans-serif; color: #333; }
-    article { display: block; text-align: left; width: 650px; margin: 0 auto; }
-    a { color: #dc8100; text-decoration: none; }
-    a:hover { color: #333; text-decoration: none; }
-    </style>
-
-<article>
-    <h1>Nous revenons très vite !</h1>
-    <div>
-        <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. If you need to you can always <a href="mailto:#">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
-        <p>&mdash; The Team</p>
-    </div>
-</article>
+<html>
+    <head>
+        <title>Site Maintenance</title>
+        <meta charset="utf-8"/>
+        <meta name="robots" content="noindex"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>
+                body { text-align: center; padding: 5%; }
+                h1 { font-size: 50px; }
+                body { font: 20px Helvetica, sans-serif; color: #333; }
+                article { display: block; text-align: left; width: 95%; margin: 0 auto; }
+                a { color: #dc8100; text-decoration: none; }
+                a:hover { color: #333; text-decoration: none; }
+                </style>
+            </head>
+    <body>
+        <article>
+            <h1>Nous revenons très vite !</h1>
+            <div>
+                <p>Nous rencontrons actuellement quelques soucis techniques. L'équipe est mobilisée pour résoudre le problème au plus vite !</p>
+                <p>Si le problème persiste, merci de nous contacter sur <a href="https://covidtracker.fr/contact/" target="_blank">CovidTracker.fr</a> ou <a href="https://twitter.com/vitemadose_off" target="_blank">Twitter</a></p>
+            </div>
+        </article>
+    </body>
+</html>

--- a/ViteMaDose/Views/Home/HomeViewController.swift
+++ b/ViteMaDose/Views/Home/HomeViewController.swift
@@ -41,14 +41,19 @@ class HomeViewController: UIViewController, Storyboarded {
     }()
 
     private lazy var dataSource = makeDataSource()
-
+    private let remoteConfiguration: RemoteConfiguration = .shared
     // MARK: - Overrides
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureViewController()
 
-        RemoteConfiguration.shared.synchronize { [unowned self] _ in
+        remoteConfiguration.synchronize { [unowned self] _ in
+            if let urlString = self.remoteConfiguration.maintenanceModeUrl {
+                let maintenanceViewController = MaintenanceViewController(urlString: urlString)
+                self.present(maintenanceViewController, animated: true)
+                return
+            }
             self.viewModel.load()
         }
     }

--- a/ViteMaDose/Views/Home/HomeViewController.swift
+++ b/ViteMaDose/Views/Home/HomeViewController.swift
@@ -49,9 +49,8 @@ class HomeViewController: UIViewController, Storyboarded {
         configureViewController()
 
         remoteConfiguration.synchronize { [unowned self] _ in
-            if let urlString = self.remoteConfiguration.maintenanceModeUrl {
-                let maintenanceViewController = MaintenanceViewController(urlString: urlString)
-                self.present(maintenanceViewController, animated: true)
+            if let maintenanceUrlString = self.remoteConfiguration.maintenanceModeUrl {
+                self.presentMaintenancePage(with: maintenanceUrlString)
                 return
             }
             self.viewModel.load()
@@ -115,6 +114,11 @@ class HomeViewController: UIViewController, Storyboarded {
         let config = SFSafariViewController.Configuration()
         let safariViewController = SFSafariViewController(url: url, configuration: config)
         present(safariViewController, animated: true)
+    }
+
+    private func presentMaintenancePage(with urlString: String) {
+        let maintenanceViewController = MaintenanceViewController(urlString: urlString)
+        present(maintenanceViewController, animated: true)
     }
 }
 

--- a/ViteMaDose/Views/Maintenance/MaintenanceViewController.swift
+++ b/ViteMaDose/Views/Maintenance/MaintenanceViewController.swift
@@ -1,0 +1,78 @@
+//
+//  MaintenanceViewController.swift
+//  ViteMaDose
+//
+//  Created by Victor Sarda on 25/04/2021.
+//
+
+import UIKit
+import WebKit
+
+class MaintenanceViewController: UIViewController {
+    let maintenanceUrl: URL?
+    lazy var webView: WKWebView = {
+        let webView = WKWebView(frame: view.bounds)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        return webView
+    }()
+
+    init(urlString: String?) {
+        if
+            let urlString = urlString,
+            let url = URL(string: urlString),
+            url.isValid
+        {
+            self.maintenanceUrl = url
+        } else {
+            self.maintenanceUrl = nil
+        }
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        self.maintenanceUrl = nil
+        super.init(coder: aDecoder)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        isModalInPresentation = true
+        configureWebView()
+
+        guard let url = maintenanceUrl else {
+            loadLocalMaintenanceHTML()
+            return
+        }
+        load(url: url)
+    }
+
+    private func configureWebView() {
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.topAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+        ])
+    }
+
+    private func load(url: URL) {
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+
+    private func loadLocalMaintenanceHTML() {
+        let localUrl = Bundle.main.url(
+            forResource: "maintenance",
+            withExtension: "html"
+        )
+
+        guard let url = localUrl else {
+            assertionFailure("Local maintenance html file not found")
+            return
+        }
+
+        webView.loadFileURL(url, allowingReadAccessTo: url)
+    }
+}

--- a/ViteMaDose/Views/Maintenance/MaintenanceViewController.swift
+++ b/ViteMaDose/Views/Maintenance/MaintenanceViewController.swift
@@ -16,9 +16,12 @@ class MaintenanceViewController: UIViewController {
         return webView
     }()
 
-    init(urlString: String?) {
+    /// Custom init with `urlString`
+    /// If the URL is invalid, it will show a default local maintenance page
+    /// Please see `Resources/maintenance.html`
+    /// - Parameter urlString: maintenance page URL
+    init(urlString: String) {
         if
-            let urlString = urlString,
             let url = URL(string: urlString),
             url.isValid
         {
@@ -41,6 +44,7 @@ class MaintenanceViewController: UIViewController {
         configureWebView()
 
         guard let url = maintenanceUrl else {
+            // Fallback
             loadLocalMaintenanceHTML()
             return
         }

--- a/ViteMaDose/remote-configuration.plist
+++ b/ViteMaDose/remote-configuration.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ios_maintenance_mode_url</key>
+	<string></string>
 	<key>url_base</key>
 	<string>https://vitemadose.gitlab.io</string>
 	<key>path_stats</key>


### PR DESCRIPTION
## Description
As mentioned in #78, we need a maintenance page feature to block the app in ever we face a major issue with the data.
Of course this is very unlikely to happen and should only be used as a last resort.

The page is a simple `UIViewController` with an embedded web view that loads a given url. If the url is somehow invalid, we show a local html page as a fallback. Please bear in mind this should never be the case.

The logic is driven by a remote config value named `ios_maintenance_mode_url`. If the value is not nil nor empty, the page will show up. The empty check on the value is primordial because, if not set, the config default value won't return `nil` but `""`.

## Attachments
|Local HTML page|Remote Page|
|-|-|
|![image](https://user-images.githubusercontent.com/6460866/116157535-0e259e00-a6e5-11eb-8b2b-1facab22cdfe.png)|![image](https://user-images.githubusercontent.com/6460866/116157551-1382e880-a6e5-11eb-87bd-6da66e7b6344.png)|

---
_Closes #78_ 