### PR TITLE
Use `AnyObject` instead of deprecated `class` for protocol

### DIFF
--- a/ViteMaDose/Helpers/Extensions/Storyboard+Common.swift
+++ b/ViteMaDose/Helpers/Extensions/Storyboard+Common.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol Storyboarded: class {
+protocol Storyboarded: AnyObject {
     static var storyboard: UIStoryboard { get }
 }
 

--- a/ViteMaDose/Helpers/Protocols/ErrorDisplayable.swift
+++ b/ViteMaDose/Helpers/Protocols/ErrorDisplayable.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol ErrorDisplayable: class {
+protocol ErrorDisplayable: AnyObject {
     func presentRetryableAndCancellableError(
         error: Error,
         retryHandler:  @escaping (_: UIAlertAction) -> Void,

--- a/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
+++ b/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
@@ -31,7 +31,7 @@ protocol CentresListViewModelProvider {
     func bookingLink(at indexPath: IndexPath) -> URL?
 }
 
-protocol CentresListViewModelDelegate: class {
+protocol CentresListViewModelDelegate: AnyObject {
     func updateLoadingState(isLoading: Bool, isEmpty: Bool)
 
     func presentLoadError(_ error: Error)

--- a/ViteMaDose/ViewModels/CountySelection/CountySelectionViewModel.swift
+++ b/ViteMaDose/ViewModels/CountySelection/CountySelectionViewModel.swift
@@ -13,7 +13,7 @@ protocol CountySelectionViewModelProvider {
     func didSelectCell(at indexPath: IndexPath)
 }
 
-protocol CountySelectionViewModelDelegate: class {
+protocol CountySelectionViewModelDelegate: AnyObject {
     func reloadTableView(with counties: Counties)
     func dismissViewController(with county: County)
 }

--- a/ViteMaDose/ViewModels/Home/HomeViewModel.swift
+++ b/ViteMaDose/ViewModels/Home/HomeViewModel.swift
@@ -35,7 +35,7 @@ protocol HomeViewModelProvider {
     var stats: Stats? { get }
 }
 
-protocol HomeViewModelDelegate: class {
+protocol HomeViewModelDelegate: AnyObject {
     func updateLoadingState(isLoading: Bool, isEmpty: Bool)
 
     func presentVaccinationCentres(for county: County)

--- a/ViteMaDose/Views/CountySelection/CountySelectionViewController.swift
+++ b/ViteMaDose/Views/CountySelection/CountySelectionViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 import Haptica
 
-protocol CountySelectionViewControllerDelegate: class {
+protocol CountySelectionViewControllerDelegate: AnyObject {
     func didSelect(county: County)
 }
 


### PR DESCRIPTION
Use `AnyObject` instead of deprecated `class` for protocol