### PR TITLE
🐛 Fixed an issue where recent searches were not always uniqued

### DIFF
--- a/ViteMaDose/Helpers/Utils/UserDefaultsUtils.swift
+++ b/ViteMaDose/Helpers/Utils/UserDefaultsUtils.swift
@@ -50,10 +50,11 @@ extension UserDefaults {
             guard case let .success(results) = searchResultData?.decode([LocationSearchResult].self) else {
                 return []
             }
-            return results
+            return results.unique(by: \.formattedName)
         }
         set {
-            guard let encoded = try? Self.encoder.encode(newValue.uniqued()) else {
+            let results = newValue.unique(by: \.formattedName)
+            guard let encoded = try? Self.encoder.encode(results) else {
                 return
             }
             setValue(encoded, forKey: Key.lastSearchResults.rawValue)


### PR DESCRIPTION
Saved recent searches were not always uniqued and could lead to a crash (identical cells on home). I made sure they always are by uniquing data by formatted name.