### PR TITLE
Fixes - Fixed home crash and added small improvements 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,3 +9,5 @@ disabled_rules:
     - nesting
     - identifier_name
 line_length: 200
+file_length: 800
+type_body_length: 500

--- a/ViteMaDose/Helpers/Extensions/Array+Commons.swift
+++ b/ViteMaDose/Helpers/Extensions/Array+Commons.swift
@@ -20,3 +20,25 @@ extension RangeReplaceableCollection {
         return filter { unique.insert($0[keyPath: keyPath]).inserted }
     }
 }
+
+public protocol OptionalProtocol {
+    associatedtype Wrapped
+    var value: Wrapped? { get }
+}
+
+extension Sequence where Element: OptionalProtocol {
+    var compacted: [Element.Wrapped] {
+        return compactMap(\.value)
+    }
+}
+
+extension Optional: OptionalProtocol {
+    public var value: Wrapped? {
+        switch self {
+        case .none:
+            return nil
+        case let .some(value):
+            return value
+        }
+    }
+}

--- a/ViteMaDose/Helpers/Utils/OnboardingManager.swift
+++ b/ViteMaDose/Helpers/Utils/OnboardingManager.swift
@@ -13,7 +13,7 @@ enum OnboardingManager {
     private static let descriptionFontSize: CGFloat = 18.0
 
     static func makeFirstPage() -> BLTNPageItem {
-        let page = BLTNPageItem(title: "Vite Ma Dose fait le plein de nouveautés !")
+        let page = BLTNPageItem(title: Localization.Onboarding.WelcomePage.title)
         page.image = "🎉".toImage(ofSize: 60)
 
         let appearance = BLTNItemAppearance()
@@ -22,8 +22,8 @@ enum OnboardingManager {
         appearance.actionButtonColor = .royalBlue
 
         page.appearance = appearance
-        page.descriptionText = "Découvrez les notifications pour ne rater aucune dose, et les chronodoses permettant à chacun de trouver un rendez-vous en 24h sans restriction."
-        page.actionButtonTitle = "Suivant"
+        page.descriptionText = Localization.Onboarding.WelcomePage.description
+        page.actionButtonTitle = Localization.Onboarding.next_button
         page.alternativeButton?.isHidden = true
         page.isDismissable = false
         page.actionHandler = { item in
@@ -34,7 +34,7 @@ enum OnboardingManager {
     }
 
     static func makeNotificationsPage() -> BLTNPageItem {
-        let page = BLTNPageItem(title: "Notifications")
+        let page = BLTNPageItem(title: Localization.Onboarding.NotificationsPage.title)
         page.image = "🔔".toImage(ofSize: 60)
 
         let appearance = BLTNItemAppearance()
@@ -43,8 +43,8 @@ enum OnboardingManager {
         appearance.actionButtonColor = .royalBlue
 
         page.appearance = appearance
-        page.descriptionText = "Pour ne rater aucun créneau de vaccination, nous avons ajouté un système de notifications ! Pour vous abonner à un centre, rien de plus simple, il suffit de toucher la cloche. Vous recevrez une alerte si nous détectons des disponibilités."
-        page.actionButtonTitle = "Suivant"
+        page.descriptionText = Localization.Onboarding.NotificationsPage.description
+        page.actionButtonTitle = Localization.Onboarding.next_button
         page.alternativeButton?.isHidden = true
         page.isDismissable = false
         page.actionHandler = { item in
@@ -56,7 +56,7 @@ enum OnboardingManager {
     }
 
     static func makeChronoDosesPage() -> BLTNPageItem {
-        let page = BLTNPageItem(title: "Chronodoses")
+        let page = BLTNPageItem(title: Localization.Onboarding.ChronodosesPage.title)
         page.image = "⚡️".toImage(ofSize: 60)
 
         let appearance = BLTNItemAppearance()
@@ -65,8 +65,8 @@ enum OnboardingManager {
         appearance.actionButtonColor = .mandy
 
         page.appearance = appearance
-        page.descriptionText = "À partir du mercredi 12 mai, vous pourrez réserver les rendez-vous de vaccination vacants du jour même et du lendemain, sans restriction. Nous les appelons les “Chronodoses”, et sont matérialisées par des éclairs et un bandeau rouge."
-        page.actionButtonTitle = "Merci !"
+        page.descriptionText = Localization.Onboarding.WelcomePage.description
+        page.actionButtonTitle = Localization.Onboarding.done_button
         page.alternativeButton?.isHidden = true
         page.isDismissable = false
         page.actionHandler = { item in

--- a/ViteMaDose/Models/VaccinationCentre.swift
+++ b/ViteMaDose/Models/VaccinationCentre.swift
@@ -168,6 +168,13 @@ extension VaccinationCentre {
         return chronoDosesCount > 0
     }
 
+    var vaccinesTypeText: String? {
+        guard let vaccineType = vaccineType, !vaccineType.isEmpty else {
+            return nil
+        }
+        return vaccineType.joined(separator: String.commaWithSpace)
+    }
+
     static var sortedByAppointment: (Self, Self) -> Bool = {
         guard
             let lhsDate = $0.nextAppointmentDate,

--- a/ViteMaDose/Resources/Localization/Localization.swift
+++ b/ViteMaDose/Resources/Localization/Localization.swift
@@ -9,6 +9,26 @@
 import Foundation
 
 enum Localization {
+    enum Onboarding {
+        static let next_button = "onboarding.next_button".localized
+        static let done_button = "onboarding.done_button".localized
+
+        enum WelcomePage {
+            static let title = "onboarding.welcome_page.title".localized
+            static let description = "onboarding.welcome_page.description".localized
+        }
+
+        enum NotificationsPage {
+            static let title = "onboarding.notifications_page.title".localized
+            static let description = "onboarding.notifications_page.description".localized
+        }
+
+        enum ChronodosesPage {
+            static let title = "onboarding.chronodoses_page.title".localized
+            static let description = "onboarding.chronodoses_page.description".localized
+        }
+    }
+
     enum Home {
         static let search_placeholder = "home.search_placeholder".localized
         static let recent_search = "home.recent_search".localized

--- a/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
@@ -6,6 +6,16 @@
   
 */
 
+// MARK: - Onboarding
+"onboarding.welcome_page.title" = "Vite Ma Dose fait le plein de nouveautés !";
+"onboarding.welcome_page.description" = "Découvrez les notifications pour ne rater aucune dose, et les chronodoses permettant à chacun de trouver un rendez-vous en 24h sans restriction.";
+"onboarding.notifications_page.title" = "Notifications";
+"onboarding.notifications_page.description" = "Pour ne rater aucun créneau de vaccination, nous avons ajouté un système de notifications ! Pour vous abonner à un centre, rien de plus simple, il suffit de toucher la cloche. Vous recevrez une alerte si nous détectons des disponibilités.";
+"onboarding.chronodoses_page.title" = "Chronodoses";
+"onboarding.chronodoses_page.description" = "À partir du mercredi 12 mai, vous pourrez réserver les rendez-vous de vaccination vacants du jour même et du lendemain, sans restriction. Nous les appelons les “Chronodoses”, et sont matérialisées par des éclairs et un bandeau rouge.";
+"onboarding.next_button" = "Suivant";
+"onboarding.done_button" = "Merci !";
+
 // MARK: - Home
 
 "home.main_title" = "Trouvez une dose de vaccin facilement et rapidement";
@@ -43,20 +53,23 @@
 "location.unavailable_name" = "Nom du centre indisponible";
 "location.unavailable_address" = "Adresse indisponible";
 
-// Location start following
+// MARK: - Location start following
+
 "location.start_following_title" = "Recevoir les notifications ?";
 "location.start_following_message" = "Vous pouvez choisir d'être notifié pour chaque changement de disponibilité ou seulement lorsque des Chronodoses sont disponibles pour ce centre.";
 "location.follow_action_title" = "Suivre";
 "location.notify_button" = "Être notifié";
 "location.follow_button" = "Suivre sans notifications";
 
-// Location stop following
+// MARK: - Location stop following
+
 "location.stop_following_title" = "Ne plus suivre ce centre ?";
 "location.stop_following_message" = "Si vous avez activé les notifications pour ce centre, elles seront désactivées.";
 "location.unfollow_action_title" = "Ne plus suivre";
 "location.stop_following_button" = "Ne plus suivre";
 
-// Error
+// MARK: - Error
+
 "error.generic.title" = "Oups! Nous avons des difficultés techniques...";
 "error.generic.retry_button" = "Réessayer";
 "error.generic.cancel_button" = "Annuler";

--- a/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
+++ b/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
@@ -144,7 +144,7 @@ class CentresListViewModel {
             addressText: centre.metadata?.address ?? Localization.Location.unavailable_address,
             phoneText: centre.formattedPhoneNumber(phoneNumberKit),
             bookingButtonText: bookingButtonText,
-            vaccineTypesText: centre.vaccineType?.joined(separator: String.commaWithSpace),
+            vaccineTypesText: centre.vaccinesTypeText,
             appointmentsCount: centre.appointmentCount,
             isAvailable: centre.isAvailable,
             partnerLogo: partnerLogo,

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -377,8 +377,10 @@ final class CentreCell: UITableViewCell {
         accessibilityElements = [
             dateLabel,
             nameLabel,
+            addressLabel,
             phoneButton,
             vaccineTypesLabel,
+            followCentreButton,
             bookingButton,
             appointmentsLabel
         ].compacted

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -48,22 +48,18 @@ public struct CentreViewData: CentreViewDataProvider, Hashable, Identifiable {
 final class CentreCell: UITableViewCell {
 
     @IBOutlet weak private var dateContainer: UIStackView!
-    @IBOutlet weak private var dateIconContainer: UIView!
     @IBOutlet weak private var dateLabel: UILabel!
 
     @IBOutlet weak private(set) var addressNameContainer: UIStackView!
-    @IBOutlet weak private var addressNameIconContainer: UIView!
     @IBOutlet weak private var nameLabel: UILabel!
     @IBOutlet weak private var addressLabel: UILabel!
 
     @IBOutlet weak private var phoneNumberContainer: UIStackView!
-    @IBOutlet weak private var phoneNumberIconContainer: UIView!
     @IBOutlet weak private var phoneButton: UIButton!
 
     @IBOutlet weak private var vaccineTypesContainer: UIStackView!
     @IBOutlet weak private var vaccineTypesLabel: UILabel!
 
-    @IBOutlet weak private var vaccineTypesIconContainer: UIView!
     @IBOutlet weak private var appointmentsLabel: UILabel!
 
     @IBOutlet weak private var bookingButton: UIButton!
@@ -76,13 +72,6 @@ final class CentreCell: UITableViewCell {
 
     @IBOutlet weak var followCentreButton: UIButton!
 
-    private lazy var iconContainers: [UIView] = [
-        dateIconContainer,
-        addressNameIconContainer,
-        phoneNumberIconContainer,
-        vaccineTypesIconContainer
-    ]
-
     var addressTapHandler: (() -> Void)?
     var phoneNumberTapHandler: (() -> Void)?
     var bookingButtonTapHandler: (() -> Void)?
@@ -91,7 +80,6 @@ final class CentreCell: UITableViewCell {
     private enum Constant {
         static let cellContentViewCornerRadius: CGFloat = 15
         static let bookingButtonCornerRadius: CGFloat = 8
-        static let iconContainersCornerRadius: CGFloat = 5
 
         static let dateFont: UIFont = .systemFont(ofSize: 14, weight: .medium)
         static let dateHighlightedFont: UIFont = .systemFont(ofSize: 16, weight: .heavy)
@@ -145,7 +133,6 @@ final class CentreCell: UITableViewCell {
         vaccineTypesLabel.text = viewData.vaccineTypesText
         vaccineTypesLabel.font = Constant.labelPrimaryFont
         vaccineTypesLabel.textColor = Constant.labelPrimaryColor
-        setCornerRadius(to: Constant.iconContainersCornerRadius, for: iconContainers)
         configureAppointmentsLabel(appointmentsCount: viewData.appointmentsCount, partnerLogo: viewData.partnerLogo, partnerName: viewData.partnerName)
     }
 

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -119,6 +119,7 @@ final class CentreCell: UITableViewCell {
         configurePhoneNumberView(viewData)
         configureChronoDoseView(viewData)
         configureFollowCentreButton(viewData)
+        configureAccessibility(viewData)
 
         let dateText = createDateText(
             dayText: viewData.dayText,
@@ -127,16 +128,6 @@ final class CentreCell: UITableViewCell {
         )
         dateLabel.attributedText = dateText
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "HH:mm"
-        if let dayText = viewData.dayText, let timeText = viewData.timeText, let dayDate = dateFormatter.date(from: timeText) {
-            let hourComponents = Calendar.current.dateComponents([.hour, .minute], from: dayDate)
-            if let localizedHours = DateComponentsFormatter.localizedString(from: hourComponents, unitsStyle: .spellOut) {
-                dateLabel.accessibilityLabel = dayText + String.space + Localization.A11y.VoiceOver.Details.from + localizedHours
-            } else {
-                dateLabel.accessibilityLabel = dayText
-            }
-        }
         nameLabel.text = viewData.addressNameText
         nameLabel.font = Constant.labelPrimaryFont
         nameLabel.textColor = Constant.labelPrimaryColor
@@ -154,14 +145,8 @@ final class CentreCell: UITableViewCell {
         vaccineTypesLabel.text = viewData.vaccineTypesText
         vaccineTypesLabel.font = Constant.labelPrimaryFont
         vaccineTypesLabel.textColor = Constant.labelPrimaryColor
-        if let vaccineName = viewData.vaccineTypesText {
-            vaccineTypesLabel.accessibilityLabel = Localization.A11y.VoiceOver.Details.vaccine.format(vaccineName)
-        }
         setCornerRadius(to: Constant.iconContainersCornerRadius, for: iconContainers)
         configureAppointmentsLabel(appointmentsCount: viewData.appointmentsCount, partnerLogo: viewData.partnerLogo, partnerName: viewData.partnerName)
-        accessibilityElements = [
-            dateLabel, nameLabel, phoneButton, vaccineTypesLabel, bookingButton, appointmentsLabel
-        ]
     }
 
     override func prepareForReuse() {
@@ -367,6 +352,36 @@ final class CentreCell: UITableViewCell {
             action: #selector(didTapFollowCentreButton),
             for: .touchUpInside
         )
+    }
+
+    private func configureAccessibility(_ viewData: CentreViewData) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm"
+        if
+            let dayText = viewData.dayText,
+            let timeText = viewData.timeText,
+            let dayDate = dateFormatter.date(from: timeText)
+        {
+            let hourComponents = Calendar.current.dateComponents([.hour, .minute], from: dayDate)
+            if let localizedHours = DateComponentsFormatter.localizedString(from: hourComponents, unitsStyle: .spellOut) {
+                dateLabel.accessibilityLabel = dayText + String.space + Localization.A11y.VoiceOver.Details.from + localizedHours
+            } else {
+                dateLabel.accessibilityLabel = dayText
+            }
+        }
+
+        if let vaccineName = viewData.vaccineTypesText {
+            vaccineTypesLabel.accessibilityLabel = Localization.A11y.VoiceOver.Details.vaccine.format(vaccineName)
+        }
+
+        accessibilityElements = [
+            dateLabel,
+            nameLabel,
+            phoneButton,
+            vaccineTypesLabel,
+            bookingButton,
+            appointmentsLabel
+        ].compacted
     }
 
     private func setCornerRadius(to radius: CGFloat, for views: [UIView]) {

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
@@ -12,18 +12,18 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Ew8-MU-ew9" customClass="CentreCell" customModule="ViteMaDose" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="379"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="346" id="Ew8-MU-ew9" customClass="CentreCell" customModule="ViteMaDose" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="346"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ew8-MU-ew9" id="Fvy-BW-4Kh">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="379"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="346"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h5C-Xa-hUC">
-                        <rect key="frame" x="24" y="12" width="366" height="355"/>
+                        <rect key="frame" x="24" y="12" width="366" height="322"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="MXb-JO-A2C">
-                                <rect key="frame" x="0.0" y="0.0" width="366" height="355"/>
+                                <rect key="frame" x="0.0" y="0.0" width="366" height="322"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="io6-wY-Ctz">
                                         <rect key="frame" x="0.0" y="0.0" width="366" height="35"/>
@@ -97,10 +97,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2ff-AN-hBk">
-                                        <rect key="frame" x="0.0" y="51" width="366" height="304"/>
+                                        <rect key="frame" x="0.0" y="51" width="366" height="271"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qjh-hq-U7W">
-                                                <rect key="frame" x="20" y="0.0" width="326" height="254.33333333333334"/>
+                                                <rect key="frame" x="20" y="0.0" width="326" height="251"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ryg-di-598">
                                                         <rect key="frame" x="0.0" y="0.0" width="326" height="25"/>
@@ -136,10 +136,10 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hTX-gS-qFO">
-                                                        <rect key="frame" x="0.0" y="35" width="326" height="50"/>
+                                                        <rect key="frame" x="0.0" y="35" width="326" height="46.666666666666657"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z5d-ai-10V">
-                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="46.666666666666664"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W0g-Bx-1q2">
                                                                         <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -168,7 +168,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D2y-su-ffI">
-                                                                <rect key="frame" x="35" y="0.0" width="291" height="50"/>
+                                                                <rect key="frame" x="35" y="0.0" width="291" height="46.666666666666664"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Name Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="eYu-df-GbP">
                                                                         <rect key="frame" x="0.0" y="0.0" width="291" height="20.333333333333332"/>
@@ -177,7 +177,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Adress Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Pg-Tm-YCx">
-                                                                        <rect key="frame" x="0.0" y="25.333333333333329" width="291" height="24.666666666666671"/>
+                                                                        <rect key="frame" x="0.0" y="25.333333333333329" width="291" height="21.333333333333329"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -188,7 +188,7 @@
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Tvm-1z-GuO">
-                                                        <rect key="frame" x="0.0" y="95" width="326" height="25"/>
+                                                        <rect key="frame" x="0.0" y="91.666666666666657" width="326" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Nc-ap-Vf5">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -225,28 +225,40 @@
                                                             <constraint firstItem="2Nc-ap-Vf5" firstAttribute="top" secondItem="Tvm-1z-GuO" secondAttribute="top" id="8Vp-fi-bjp"/>
                                                         </constraints>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="PCa-bL-lM5">
-                                                        <rect key="frame" x="0.0" y="130" width="326" height="25"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5H-Fb-wwZ">
+                                                        <rect key="frame" x="0.0" y="126.66666666666666" width="326" height="25"/>
                                                         <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EFc-D1-4sc">
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="juo-5y-WUd">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                                 <subviews>
-                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="210-YX-XWZ">
-                                                                        <rect key="frame" x="2" y="2" width="21" height="21"/>
-                                                                        <color key="tintColor" systemColor="secondaryLabelColor"/>
-                                                                    </imageView>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dMy-hk-SNt">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                        <subviews>
+                                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GgM-L0-fCk">
+                                                                                <rect key="frame" x="2" y="2" width="21" height="21"/>
+                                                                                <color key="tintColor" systemColor="secondaryLabelColor"/>
+                                                                            </imageView>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="And-S3-eO4"/>
+                                                                            <constraint firstAttribute="bottom" secondItem="GgM-L0-fCk" secondAttribute="bottom" constant="2" id="DH5-Ap-ZTM"/>
+                                                                            <constraint firstAttribute="width" constant="25" id="YfW-Vn-GGK"/>
+                                                                            <constraint firstAttribute="trailing" secondItem="GgM-L0-fCk" secondAttribute="trailing" constant="2" id="dGw-nW-Alb"/>
+                                                                            <constraint firstItem="GgM-L0-fCk" firstAttribute="top" secondItem="dMy-hk-SNt" secondAttribute="top" constant="2" id="hbu-bu-8R0"/>
+                                                                            <constraint firstItem="GgM-L0-fCk" firstAttribute="leading" secondItem="dMy-hk-SNt" secondAttribute="leading" constant="2" id="oL0-VS-ZiB"/>
+                                                                        </constraints>
+                                                                    </view>
                                                                 </subviews>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="4sO-eL-e1P"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="210-YX-XWZ" secondAttribute="trailing" constant="2" id="Sl3-Vb-naN"/>
-                                                                    <constraint firstAttribute="bottom" secondItem="210-YX-XWZ" secondAttribute="bottom" constant="2" id="THY-Ja-3uF"/>
-                                                                    <constraint firstAttribute="width" constant="25" id="cRd-tm-1YU"/>
-                                                                    <constraint firstItem="210-YX-XWZ" firstAttribute="leading" secondItem="EFc-D1-4sc" secondAttribute="leading" constant="2" id="kRb-C0-GmI"/>
-                                                                    <constraint firstItem="210-YX-XWZ" firstAttribute="top" secondItem="EFc-D1-4sc" secondAttribute="top" constant="2" id="x0W-T3-5mU"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="9Xy-f5-Zln"/>
+                                                                    <constraint firstItem="dMy-hk-SNt" firstAttribute="top" secondItem="juo-5y-WUd" secondAttribute="top" id="BfL-Bn-rEy"/>
+                                                                    <constraint firstItem="dMy-hk-SNt" firstAttribute="centerX" secondItem="juo-5y-WUd" secondAttribute="centerX" id="lei-h2-Fps"/>
+                                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="25" id="x5X-FQ-yxV"/>
                                                                 </constraints>
                                                             </view>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Vaccine Types Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xW2-BM-CtY">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Vaccine Types" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="tFU-d1-nKp">
                                                                 <rect key="frame" x="35" y="0.0" width="291" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
@@ -254,12 +266,9 @@
                                                             </label>
                                                         </subviews>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstItem="EFc-D1-4sc" firstAttribute="top" secondItem="PCa-bL-lM5" secondAttribute="top" id="JBS-pX-Fhp"/>
-                                                        </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="AGf-cx-Qph">
-                                                        <rect key="frame" x="0.0" y="165" width="326" height="59"/>
+                                                        <rect key="frame" x="0.0" y="161.66666666666666" width="326" height="59"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XKQ-RD-2fb" userLabel="Spacer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="326" height="15"/>
@@ -298,7 +307,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Appointments Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hFB-rb-sEa">
-                                                        <rect key="frame" x="0.0" y="234" width="326" height="20.333333333333343"/>
+                                                        <rect key="frame" x="0.0" y="230.66666666666669" width="326" height="20.333333333333343"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -337,26 +346,22 @@
             <connections>
                 <outlet property="addressLabel" destination="5Pg-Tm-YCx" id="CJm-XF-0P2"/>
                 <outlet property="addressNameContainer" destination="hTX-gS-qFO" id="VaQ-cH-0Qx"/>
-                <outlet property="addressNameIconContainer" destination="W0g-Bx-1q2" id="5yD-UH-acE"/>
                 <outlet property="appointmentsLabel" destination="hFB-rb-sEa" id="Fbr-68-cnm"/>
                 <outlet property="bookingButton" destination="4oP-8v-7f8" id="dbo-sT-TaC"/>
                 <outlet property="cellContentView" destination="h5C-Xa-hUC" id="2xr-L7-qUy"/>
                 <outlet property="chronoDoseLabel" destination="VaG-GN-B5Y" id="gno-FZ-CbZ"/>
                 <outlet property="chronoDoseViewContainer" destination="io6-wY-Ctz" id="6ny-D1-xNU"/>
                 <outlet property="dateContainer" destination="ryg-di-598" id="I2m-Ji-RMO"/>
-                <outlet property="dateIconContainer" destination="XXI-0S-lWr" id="bfe-gZ-xtZ"/>
                 <outlet property="dateLabel" destination="vca-O5-a2x" id="FHh-uY-y3T"/>
                 <outlet property="followCentreButton" destination="zAo-oT-oBY" id="rka-Ja-HMJ"/>
                 <outlet property="nameLabel" destination="eYu-df-GbP" id="2Fp-YL-Wga"/>
                 <outlet property="phoneButton" destination="d0x-2N-C1e" id="drG-Kh-pC5"/>
                 <outlet property="phoneNumberContainer" destination="Tvm-1z-GuO" id="68t-no-vxL"/>
-                <outlet property="phoneNumberIconContainer" destination="2Nc-ap-Vf5" id="wYq-QL-oTj"/>
-                <outlet property="vaccineTypeImageView" destination="210-YX-XWZ" id="K92-S4-ZC4"/>
-                <outlet property="vaccineTypesContainer" destination="PCa-bL-lM5" id="MVc-Xa-Gx7"/>
-                <outlet property="vaccineTypesIconContainer" destination="EFc-D1-4sc" id="20K-wl-AeK"/>
-                <outlet property="vaccineTypesLabel" destination="xW2-BM-CtY" id="vuL-lk-ucF"/>
+                <outlet property="vaccineTypeImageView" destination="GgM-L0-fCk" id="M0s-4g-VSq"/>
+                <outlet property="vaccineTypesContainer" destination="E5H-Fb-wwZ" id="Qsh-oe-gDw"/>
+                <outlet property="vaccineTypesLabel" destination="tFU-d1-nKp" id="ORj-6R-GLH"/>
             </connections>
-            <point key="canvasLocation" x="244.92753623188409" y="267.79891304347831"/>
+            <point key="canvasLocation" x="244.92753623188409" y="254.34782608695653"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/ViteMaDose/Views/Home/HomeViewController.swift
+++ b/ViteMaDose/Views/Home/HomeViewController.swift
@@ -59,11 +59,7 @@ final class HomeViewController: UIViewController, Storyboarded {
         super.viewDidLoad()
         configureViewController()
 
-        remoteConfiguration.synchronize { [unowned self] _ in
-            if let maintenanceUrlString = self.remoteConfiguration.maintenanceModeUrl {
-                self.presentMaintenancePage(with: maintenanceUrlString)
-                return
-            }
+        remoteConfiguration.synchronize { _ in
             self.viewModel.load()
         }
     }


### PR DESCRIPTION
## Description
I removed `unowned self` from `viewDidLoad` as it was the cause of our top crash. Unowned is not needed since self can't create a retain cycle here.
I also removed the maintenance page check as we're now using Firebase In App messaging (I'll remove the page in a different PR).

Other changes :
- Removed warnings
- Localized the onboarding texts
- Fixed accessibility on centre cells
- Fixed an issue where vaccin types would show an empty text when the array from backend is empty
- Made vaccin types label multiline on the centre cell
