### PR TITLE
Feature - Open URL from push

### DIFF
--- a/ViteMaDose/Views/Home/HomeViewController.swift
+++ b/ViteMaDose/Views/Home/HomeViewController.swift
@@ -59,11 +59,7 @@ final class HomeViewController: UIViewController, Storyboarded {
         super.viewDidLoad()
         configureViewController()
 
-        remoteConfiguration.synchronize { [unowned self] _ in
-            if let maintenanceUrlString = self.remoteConfiguration.maintenanceModeUrl {
-                self.presentMaintenancePage(with: maintenanceUrlString)
-                return
-            }
+        remoteConfiguration.synchronize { _ in
             self.viewModel.load()
         }
     }


### PR DESCRIPTION
## Description
Simple PR to parse `url` from a push notification payload and show a `SFSafariViewController`.
This will be useful for users when they tap on push as it will instantly open the centre URL.

## Attachments
|Before Tap|After Tap|
|-|-|
|![IMG_1719](https://user-images.githubusercontent.com/6460866/118886670-2908be00-b8f1-11eb-8719-6209e7dcdfba.PNG)|![IMG_1720](https://user-images.githubusercontent.com/6460866/118886653-24dca080-b8f1-11eb-95b6-125c74de6e74.PNG)|
