### PR TITLE
🐛 Fixed the follow centre bottom sheet source view on iPad

### DIFF
--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -67,10 +67,10 @@ final class CentreCell: UITableViewCell {
 
     @IBOutlet weak private var vaccineTypeImageView: UIImageView!
 
-    @IBOutlet weak var chronoDoseViewContainer: UIView!
-    @IBOutlet weak var chronoDoseLabel: UILabel!
+    @IBOutlet weak private var chronoDoseViewContainer: UIView!
+    @IBOutlet weak private var chronoDoseLabel: UILabel!
 
-    @IBOutlet weak var followCentreButton: UIButton!
+    @IBOutlet weak private(set) var followCentreButton: UIButton!
 
     var addressTapHandler: (() -> Void)?
     var phoneNumberTapHandler: (() -> Void)?

--- a/ViteMaDose/Views/CentresList/CentresListViewController.swift
+++ b/ViteMaDose/Views/CentresList/CentresListViewController.swift
@@ -296,7 +296,7 @@ extension CentresListViewController: UITableViewDelegate {
         present(actionSheet, animated: true)
     }
 
-    private func presentFollowCentreBottomSheet(forCell cell: UITableViewCell, atIndexPath indexPath: IndexPath) {
+    private func presentFollowCentreBottomSheet(forCell cell: CentreCell, atIndexPath indexPath: IndexPath) {
         let bottomSheet = UIAlertController(
             title: Localization.Location.start_following_title,
             message: Localization.Location.start_following_message,
@@ -320,12 +320,12 @@ extension CentresListViewController: UITableViewDelegate {
         bottomSheet.addAction(allNotificationsAction)
         bottomSheet.addAction(chronoDosesNotificationsAction)
         bottomSheet.addAction(cancelAction)
-        bottomSheet.popoverPresentationController?.sourceView = cell
+        bottomSheet.popoverPresentationController?.sourceView = cell.followCentreButton
 
         present(bottomSheet, animated: true)
     }
 
-    private func presentUnfollowCentreBottomSheet(forCell cell: UITableViewCell, atIndexPath indexPath: IndexPath) {
+    private func presentUnfollowCentreBottomSheet(forCell cell: CentreCell, atIndexPath indexPath: IndexPath) {
         let bottomSheet = UIAlertController(
             title: Localization.Location.stop_following_title,
             message: Localization.Location.stop_following_message,
@@ -340,7 +340,7 @@ extension CentresListViewController: UITableViewDelegate {
 
         bottomSheet.addAction(unfollowAction)
         bottomSheet.addAction(cancelAction)
-        bottomSheet.popoverPresentationController?.sourceView = view
+        bottomSheet.popoverPresentationController?.sourceView = cell.followCentreButton
 
         self.present(bottomSheet, animated: true)
     }


### PR DESCRIPTION
Small fix as someone raised this issue in the app store reviews.
On iPad there was a bug where you couldn't _unfollow_ a centre to stop receiving notifications.
This was due to the bottom sheet `sourceView` not being set correctly. I've changed it to use the cell button, as expected.
This doesn't change the behaviour on iPhone.

![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-05-20 at 19 27 30](https://user-images.githubusercontent.com/6460866/119030459-d0452e00-b9a1-11eb-82b0-8a295bdd5bb2.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-05-20 at 19 27 34](https://user-images.githubusercontent.com/6460866/119030449-cd4a3d80-b9a1-11eb-9f1f-5ef0c30fe3cd.png)
