### PR TITLE
Forge string dedicated to accessibility label to improve vocalization of big numbers containing whitespaces

### DIFF
--- a/ViteMaDose/Helpers/Extensions/String+Commons.swift
+++ b/ViteMaDose/Helpers/Extensions/String+Commons.swift
@@ -77,3 +77,55 @@ extension Optional where Wrapped: StringProtocol {
         return self ?? ""
     }
 }
+
+// MARK: - String + A11Y
+
+extension String {
+
+    /// For the current string, returns a new version without numbers containing spaces.
+    /// Thus big numbers which are basically written with whitespaces will be packed, and _VoiceOver_ will vocalize them as a whole single number
+    /// and not a suite of individual digits.
+    /// For example:
+    ///     * a number "42000" will remain "42000" (llike a zip code)
+    ///     * a number "687 713" will be converted to "687 713" (like a number of available slots)
+    /// - Returns: The final string with "vocalizable" numbers
+    public func forgeVocalizableText() -> String {
+        var numbers = extractNumbers()
+        return merge(inAll: &numbers, for: self)
+    }
+
+    /// Extract numbers from current string, supposing we don't know where they are.
+    ///  The string is splitted by whitespaces. If we find an alone number word, we keep it. If wee find two consecutives or more number words, we merge them into one.
+    /// - Returns: An array of string where each element is a number
+    fileprivate func extractNumbers() -> [String] {
+        var numbers = [String]()
+        let words = self.split(separator: " ")
+        for word in words where Int(word.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()) != nil {
+            numbers.append(String(word))
+        }
+        return numbers
+    }
+
+    /// For each _element_ in `numbers` for the given `string`,  removes the whitespace inside this _element_.
+    /// Recursive version to avoid to have nested loops with too much iterations.
+    /// - Parameters:
+    ///     - numbers: Array of numbers to process, containing strings like "1234" and "123 456", modified at each call
+    ///     - string: The string to process which will be smaller and smaller at each run
+    /// - Returns: The result string, with non-numbers and numbrs without whitespaces
+    fileprivate func merge(inAll numbers: inout [String], for string: String) -> String {
+        guard numbers.count > 0 else {
+            return string
+        }
+        var resultString = ""
+        var fragments = string.components(separatedBy: numbers[0])
+        if fragments.count > 0 {
+            if !fragments[0].isEmpty { // Non-number fragment
+                resultString += fragments[0] + numbers[0].filter { !$0.isWhitespace }
+            }
+            numbers.removeFirst() // One word less to process
+            fragments.removeFirst() // No need to process begining of the string
+            resultString += merge(inAll: &numbers, for: fragments.joined())
+        }
+        return resultString
+    }
+}

--- a/ViteMaDose/Views/Home/Cells/HomeTitleCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeTitleCell.swift
@@ -57,9 +57,12 @@ class HomeTitleCell: UITableViewCell {
         titleLabel.adjustsFontForContentSizeCategory = true
         descriptionLabel.adjustsFontForContentSizeCategory = true
 
+        titleLabel?.accessibilityLabel = viewData.titleText.string.forgeVocalizableText()
+
         topConstraint.constant = viewData.topMargin
         bottomConstraint.constant = viewData.bottomMargin
     }
+
 }
 
 extension HomeTitleCell {


### PR DESCRIPTION
Closes #192

## Description

Provides a simple method to manage numbers in string which have whitespaces inside where _VoiceOver_ i not able to make a suitable vocalization. The _HomeCell_ displaying the number of slots for a location was bad vocalized. For example, the number "48 513" was vocalized digit by digit like "4-8-5-1-3", instead of the whole number. Now its fixed with a simple method looking for numbers in a string and removing whitespaces.

## Changes
- Add extension in _String_  to have such method
- Add accessibility label in the title field for the home cell used in result screen

## Related issue

Fixes #132 

## What I tested
Tests with custom hard-coded string and also with bunch of manuel requests using _VoiceOver_

## Regression risks
- None, only a custom string is created from another, and this new string defined an accessibility label which was undefined until now

## Screenshots

Nope.

## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
