### PR TITLE
Text size in followed centers cell follows A11Y rules

### DIFF
--- a/ViteMaDose/Views/Home/Cells/HomeFollowedCentresCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeFollowedCentresCell.swift
@@ -18,6 +18,7 @@ final class HomeFollowedCentresCell: UITableViewCell {
         static let nameTextColor: UIColor = .label
         static let codeBackgroundColor: UIColor = .royalBlue
         static let cellBackgroundColor: UIColor = .tertiarySystemBackground
+        static let titleFont: UIFont = .accessibleTitle1Bold
         static let labelsFont: UIFont = .rounded(ofSize: 18, weight: .bold)
         static let viewsCornerRadius: CGFloat = 15
     }
@@ -33,7 +34,7 @@ final class HomeFollowedCentresCell: UITableViewCell {
 
         titleLabel.text = "Mes centres suivis"
         titleLabel.textColor = .label
-        titleLabel.font = .rounded(ofSize: 18, weight: .bold)
+        titleLabel.font = Constant.titleFont
     }
 
     override func prepareForReuse() {


### PR DESCRIPTION
## Description
When a11y feature is enabled with big text sizes, the title of "mes centres suivi" cell was not changed.
Now it follows the a11y settings like the other cells.

## Changes
- Add accessible text size for _HomeFollowedCentresCell_

## Related issue
Fixes #131 

## What I tested
- Define a11y settings like described in the issue
- Add a center to get the "followed centers" cell
- Check if text size is changed and not always "little" anymore

## Regression risks
- None

## Screenshots
_If applicable, add screenshots to help explain the fix. Otherwise please remove this section_
|Before|After|
|-|-|
| ![IMG_9362](https://user-images.githubusercontent.com/7559007/142837853-06d797f2-71c7-4bb6-ae20-5dabc539f2fc.PNG)
| ![IMG_9361](https://user-images.githubusercontent.com/7559007/142837455-9d8c8339-5cd0-4578-9486-f656c01e0a78.PNG)|




## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
