### PR TITLE
🐛 Fixed wrong twitter account link in settings

### DIFF
--- a/ViteMaDose/Views/Settings/SettingsViewController.swift
+++ b/ViteMaDose/Views/Settings/SettingsViewController.swift
@@ -16,7 +16,7 @@ final class SettingsViewController: UIViewController, Storyboarded {
 
     @IBOutlet private var tableView: UITableView!
 
-    /// Cells to add in the embeded `tableView`
+    /// Cells to add in the embedded `tableView`
     private lazy var cellsTypes: [SettingsDataType] = [
         .header, .website, .contact, .twitter, .appSourceCode, .systemSettings
     ]
@@ -80,11 +80,11 @@ extension SettingsViewController: UITableViewDelegate {
         case .contact:
             openUrl("https://covidtracker.fr/contact/")
         case .twitter:
-            openUrl("https://twitter.com/covidtracker_fr")
+            openUrl("https://twitter.com/ViteMaDose_off")
         case .appSourceCode:
             openUrl("https://github.com/CovidTrackerFr/vitemadose-ios")
         case .systemSettings:
-            UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+            UIApplication.shared.open(URL(staticString: UIApplication.openSettingsURLString))
         case .header, .none:
             break
         }


### PR DESCRIPTION
## Description
Fixed wrong twitter account link in settings

## Related issue
Closes #140 

## What I tested
- Link is correct

## Regression risks
- None

## Screenshots
![image](https://user-images.githubusercontent.com/6460866/143769991-cc866dd1-cd8a-40ed-a5be-ec6524ac07a4.png)

## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [ ] I tested my changes on real device
- [x] My changes generate no new warnings
- [ ] I have commented my code in hard-to-understand areas
- [ ] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
