### PR TITLE
fix: #155 - label text size for followed centers cell

### DIFF
--- a/ViteMaDose/Views/Home/Cells/HomeFollowedCentresCell.swift
+++ b/ViteMaDose/Views/Home/Cells/HomeFollowedCentresCell.swift
@@ -18,7 +18,7 @@ final class HomeFollowedCentresCell: UITableViewCell {
         static let nameTextColor: UIColor = .label
         static let codeBackgroundColor: UIColor = .royalBlue
         static let cellBackgroundColor: UIColor = .tertiarySystemBackground
-        static let titleFont: UIFont = .accessibleTitle1Bold
+        static let titleFont: UIFont = .accessibleBodyBold
         static let labelsFont: UIFont = .rounded(ofSize: 18, weight: .bold)
         static let viewsCornerRadius: CGFloat = 15
     }


### PR DESCRIPTION
## Description
Fix font size of followed centers label

## Changes
- Change size of the label

## Related issue
_Link to the [Github issue #155](https://github.com/CovidTrackerFr/vitemadose-ios/issues/155)_

## What I tested
- Using simulator and device
- Test allo with a11y feature enabled

## Regression risks
- _List any regression risk if applicable_

## Screenshots
_If applicable, add screenshots to help explain the fix. Otherwise please remove this section_
|Before|After|
|-|-|
| ![144824868-63460725-7fcd-48ee-b9c2-8b8231aa3e5a](https://user-images.githubusercontent.com/7559007/144934495-e9cff9a2-db15-42b2-802f-a79f9bd0482a.png)|![Simulator Screen Shot - iPhone Xs 14 5 - 2021-12-06 at 23 34 49](https://user-images.githubusercontent.com/7559007/144934452-f94470d6-7a16-4f5a-b98e-9ea4024f8a3a.png) |


## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
