### PR TITLE
Update tags management for kids shot to avoid app bug

### DIFF
--- a/ViteMaDose/Models/DailySlot.swift
+++ b/ViteMaDose/Models/DailySlot.swift
@@ -41,6 +41,7 @@ extension SlotsPerCategory {
         case all
         case firstOfSecondDose = "first_or_second_dose"
         case thirdDose = "third_dose"
+        case kidsFirstDose = "kids_first_dose"
         case unknown = "unknown_dose"
     }
 }


### PR DESCRIPTION
## Description
Version 1.4.0 is not working because missing management of "kids first dose" tag.

## Changes
- Only update _DailySlots_ to add missing case in _Codable_ enum

## Related issue

_Link to the [Github #164 issue](https://github.com/CovidTrackerFr/vitemadose-ios/issues/164)_

## What I tested

- Add fix
- Tested with random searches
- Tested with "in history" searches

## Regression risks

- No regression identified, this fix is about a regression also.

## Screenshots

_Not relevant_

## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
