### PR TITLE
fix: #162 #103 - mapharma time and bug with unmanaged tag for kids first dose

### DIFF
--- a/ViteMaDose/Helpers/Extensions/String+Commons.swift
+++ b/ViteMaDose/Helpers/Extensions/String+Commons.swift
@@ -17,9 +17,18 @@ extension String {
     /// This function will try to parse the `String` as a Date
     /// using `SwiftDate`.
     /// If parsing fails, it will try to parse as an `ISO` date as a fallback
-    /// - Parameter region: custom option `Region`
-    /// - Returns: optional `Date`
+    /// - Parameters:
+    ///   - style: custom `DateToStringStyles`
+    ///   - region: custom option `Region`
+    /// - Returns: optional `String`
     func toString(with style: DateToStringStyles, region: Region) -> String? {
+        // Fix #102: If it is a timezoned date and the timezone is not specified
+        if contains("T") && !contains("+") {
+            // Add missing timezone
+            let diff = region.timeZone.secondsFromGMT() / 3600 // 1 or 2 depending on summer or winter time
+            return (self + "+0\(diff):00").toString(with: style, region: region)
+        }
+
         let date = toDate(nil, region: region) ?? toISODate(nil, region: region)
         return date?.toString(style)
     }

--- a/ViteMaDose/Models/DailySlot.swift
+++ b/ViteMaDose/Models/DailySlot.swift
@@ -41,6 +41,7 @@ extension SlotsPerCategory {
         case all
         case firstOfSecondDose = "first_or_second_dose"
         case thirdDose = "third_dose"
+        case kidsFirstDose = "kids_first_dose"
         case unknown = "unknown_dose"
     }
 }


### PR DESCRIPTION
See #162 #165 #103

1% release shows the app is not working because of unmanaged tag in daily slots.

_Not: emergency fix_