### PR TITLE
Update icons for settings and onboarding

### DIFF
--- a/ViteMaDose/Helpers/Utils/OnboardingManager.swift
+++ b/ViteMaDose/Helpers/Utils/OnboardingManager.swift
@@ -66,6 +66,28 @@ enum OnboardingManager {
 
         page.appearance = appearance
         page.descriptionText = Localization.Onboarding.ThirdDosePage.description
+        page.actionButtonTitle = Localization.Onboarding.next_button
+        page.alternativeButton?.isHidden = true
+        page.isDismissable = false
+        page.actionHandler = { item in
+            item.manager?.displayNextItem()
+        }
+        page.next = settingsPage
+
+        return page
+    }()
+
+    static let settingsPage: BLTNPageItem = {
+        let page = BLTNPageItem(title: Localization.Onboarding.SettingsPage.title)
+        page.image = "📚".toImage(ofSize: 60)
+
+        let appearance = BLTNItemAppearance()
+        appearance.titleFontSize = Self.titleFontSize
+        appearance.descriptionFontSize = Self.descriptionFontSize
+        appearance.actionButtonColor = .royalBlue
+
+        page.appearance = appearance
+        page.descriptionText = Localization.Onboarding.SettingsPage.description
         page.actionButtonTitle = Localization.Onboarding.done_button
         page.alternativeButton?.isHidden = true
         page.isDismissable = false

--- a/ViteMaDose/Resources/Localization/Localization.swift
+++ b/ViteMaDose/Resources/Localization/Localization.swift
@@ -28,6 +28,11 @@ enum Localization {
             static let title = "onboarding.thirddose_page.title".localized
             static let description = "onboarding.thirddose_page.description".localized
         }
+
+        enum SettingsPage {
+            static let title = "onboarding.settingspage.title".localized
+            static let description = "onboarding.settingspage.description".localized
+        }
     }
 
     enum Home {

--- a/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
@@ -12,6 +12,8 @@
 "onboarding.notifications_page.description" = "Pour ne rater aucun créneau de vaccination, nous avons ajouté un système de notifications ! Pour vous abonner à un centre, rien de plus simple, il suffit de toucher la cloche. Vous recevrez une alerte si nous détectons des disponibilités.";
 "onboarding.thirddose_page.title" = "Dose de rappel";
 "onboarding.thirddose_page.description" = "Vous pouvez désormais afficher les lieux de vaccination ayant des doses de rappel disponible.";
+"onboarding.settingspage.title" = "Envie d'en savoir plus ?";
+"onboarding.settingspage.description" = "Retrouvez différentes infos sur le projet via le menu des réglages. Contributeurs, site web, réseaux sociaux, code source... les curieuses et curieux seront ravis !";
 "onboarding.next_button" = "Suivant";
 "onboarding.done_button" = "Merci !";
 

--- a/ViteMaDose/Views/Home/HomeViewController.storyboard
+++ b/ViteMaDose/Views/Home/HomeViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bCs-t9-dNl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bCs-t9-dNl">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -45,7 +45,7 @@
                                                             <constraint firstAttribute="height" constant="50" id="RH2-Kc-8cR"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                                        <state key="normal" image="gearshape.fill" catalog="system"/>
+                                                        <state key="normal" image="gear" catalog="system"/>
                                                         <connections>
                                                             <action selector="goToSettings:" destination="u8L-Ja-9UJ" eventType="touchUpInside" id="FVJ-wQ-y3K"/>
                                                         </connections>
@@ -120,7 +120,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="gearshape.fill" catalog="system" width="128" height="121"/>
+        <image name="gear" catalog="system" width="128" height="119"/>
         <image name="logo" width="166" height="44"/>
         <namedColor name="royalBlue">
             <color red="0.33300000429153442" green="0.37999999523162842" blue="0.85100001096725464" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/ViteMaDose/Views/Settings/Cells/SettingsCell.swift
+++ b/ViteMaDose/Views/Settings/Cells/SettingsCell.swift
@@ -46,7 +46,7 @@ private extension SettingsDataType {
         case .appSourceCode:
             imageName = "wand.and.stars"
         case .systemSettings:
-            imageName = "wrench.and.screwdriver.fill"
+            imageName = "wrench"
         }
 
         if let imageName = imageName, let image = UIImage(systemName: imageName, withConfiguration: configuration) {

--- a/ViteMaDose/Views/Settings/Cells/SettingsCell.swift
+++ b/ViteMaDose/Views/Settings/Cells/SettingsCell.swift
@@ -44,7 +44,7 @@ private extension SettingsDataType {
         case .twitter:
             imageName = "pencil"
         case .appSourceCode:
-            imageName = "cursorarrow.square"
+            imageName = "wand.and.stars"
         case .systemSettings:
             imageName = "wrench.and.screwdriver.fill"
         }


### PR DESCRIPTION
## Description
Settings screen have some missing icons if iOS 13 is in use.
The onboarding manager does not have an entry about the settings screen.

## Changes
- Add SF Symbols compatible for IOS 13, 14 and 15
- Add entry in onboarding manager

## Related issue

_Link to the [Github issue #168](https://github.com/CovidTrackerFr/vitemadose-ios/issues/168)_

## What I tested
- Tested settings with iOS 13 (simulator, iPhone SSE 2nd Gen) and iOS 15 (iPhone 12 Pro)

## Regression risks
- No regression, feature not yet delivered

## Screenshots
_For screenshots before fix, see the issue_

<img width="435" alt="settings" src="https://user-images.githubusercontent.com/7559007/147970649-a3fbcf67-08e0-4a59-a19f-72e7f532b031.png">
<img width="435" alt="home screen" src="https://user-images.githubusercontent.com/7559007/147970652-4031e62f-263b-4984-89ff-b6e55fe49f70.png">


## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
