### PR TITLE
[Feature] [#144] Display type of vaccination center

### DIFF
--- a/ViteMaDose/Helpers/Utils/AppAnalytics.swift
+++ b/ViteMaDose/Helpers/Utils/AppAnalytics.swift
@@ -40,7 +40,7 @@ enum AppAnalytics {
         let eventName = "rdv_click" // TODO 1.4.1: Re-implement `rdv_verify`
         let department = vaccinationCentre.departement.emptyIfNil.lowercased()
         let name = vaccinationCentre.nom.emptyIfNil.lowercased()
-        let type = vaccinationCentre.type.emptyIfNil.lowercased()
+        let type = vaccinationCentre.type?.rawValue.lowercased() ?? ""
         let platform = vaccinationCentre.plateforme.emptyIfNil.lowercased()
         let vaccine = (vaccinationCentre.vaccineType?.joined(separator: ",").lowercased()).emptyIfNil
 

--- a/ViteMaDose/Models/VaccinationCentre.swift
+++ b/ViteMaDose/Models/VaccinationCentre.swift
@@ -10,7 +10,7 @@ import MapKit
 import PhoneNumberKit
 import SwiftDate
 
-// MARK: - VaccinationCentre
+// MARK: - Vaccination Centre
 
 public struct VaccinationCentre: Codable, Hashable, Identifiable {
     private let gid: String?
@@ -22,7 +22,7 @@ public struct VaccinationCentre: Codable, Hashable, Identifiable {
     let metadata: Metadata?
     let prochainRdv: String?
     let plateforme: String?
-    let type: String?
+    let type: CentreType?
     let vaccineType: [String]?
     let appointmentSchedules: [AppointmentSchedule?]?
 
@@ -47,6 +47,9 @@ public struct VaccinationCentre: Codable, Hashable, Identifiable {
 }
 
 extension VaccinationCentre {
+
+    // MARK: Location
+
     struct Location: Codable, Hashable {
         let longitude: Double?
         let latitude: Double?
@@ -59,6 +62,8 @@ extension VaccinationCentre {
         }
     }
 
+    // MARK: Metadata
+
     struct Metadata: Codable, Hashable {
         let address: String?
         let phoneNumber: String?
@@ -70,6 +75,8 @@ extension VaccinationCentre {
             case businessHours = "business_hours"
         }
     }
+
+    // MARK: Appointment Schedule
 
     struct AppointmentSchedule: Codable, Hashable {
         let name: String?
@@ -85,13 +92,54 @@ extension VaccinationCentre {
         }
     }
 
+    // MARK: Centre Type
+
+    public enum CentreType: String, Codable, Hashable {
+        case vaccinationCenter = "vaccination-center"
+        case drugstore = "drugstore"
+        case generalPractitioner = "general-practitioner"
+        case medecin = "medecin"
+
+        public init?(rawValue: String) {
+            switch rawValue {
+            case "vaccination-center":
+                self = .vaccinationCenter
+            case "drugstore":
+                self = .drugstore
+            case "general-practitioner":
+                self = .generalPractitioner
+            case "medecin":
+                self = .medecin
+            default:
+                assertionFailure("Received value '\(rawValue) but it's not managed")
+                return nil
+            }
+        }
+
+        var localized: String {
+            switch self {
+            case .vaccinationCenter:
+                return Localization.Location.Types.vaccination_center
+            case .drugstore:
+                return Localization.Location.Types.drugstore
+            case .generalPractitioner:
+                return Localization.Location.Types.general_practicioner
+            case .medecin:
+                return Localization.Location.Types.medecin
+            }
+        }
+    }
 }
+
+// MARK: Sequence of Vaccination Centre
 
 extension Sequence where Element == VaccinationCentre {
     var allAvailableCentresCount: Int {
         return reduce(0) { $0 + $1.isAvailable.intValue }
     }
 }
+
+// MARK: - Vaccination Centre - computed properties
 
 extension VaccinationCentre {
     var isAvailable: Bool {
@@ -194,7 +242,7 @@ extension VaccinationCentre {
     }
 }
 
-// MARK: - VaccinationCentres
+// MARK: - Vaccination Centres
 
 struct VaccinationCentres: Codable, Hashable {
     let lastUpdated: String?
@@ -226,6 +274,8 @@ struct VaccinationCentres: Codable, Hashable {
         case centresIndisponibles = "centres_indisponibles"
     }
 }
+
+// MARK: - Department Vaccination Centres
 
 typealias DepartmentVaccinationCentres = [VaccinationCentres]
 

--- a/ViteMaDose/Resources/Localization/Localization.swift
+++ b/ViteMaDose/Resources/Localization/Localization.swift
@@ -116,6 +116,13 @@ enum Localization {
         static let stop_following_title = "location.stop_following_title".localized
         static let stop_following_message = "location.stop_following_message".localized
         static let stop_following_button = "location.stop_following_button".localized
+
+        enum Types {
+            static let vaccination_center = "location.types.vaccination_center".localized
+            static let drugstore = "location.types.drugstore".localized
+            static let general_practicioner = "location.types.general_practicioner".localized
+            static let medecin = "location.types.medecin".localized
+        }
     }
 
     enum Settings {

--- a/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
@@ -66,6 +66,13 @@
 "location.unavailable_name" = "Nom du centre indisponible";
 "location.unavailable_address" = "Adresse indisponible";
 
+// MARK: - Location Types
+
+"location.types.vaccination_center" = "Centre de vaccination";
+"location.types.drugstore" = "Pharmacie";
+"location.types.general_practicioner" = "Médecin généraliste";
+"location.types.medecin" = "Médecin";
+
 // MARK: - Location start following
 
 "location.start_following_title" = "Recevoir les notifications ?";

--- a/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
+++ b/ViteMaDose/ViewModels/CentresList/CentresListViewModel.swift
@@ -171,6 +171,7 @@ class CentresListViewModel {
             phoneText: centre.formattedPhoneNumber(phoneNumberKit),
             bookingButtonText: bookingButtonText,
             vaccineTypesText: centre.vaccinesTypeText,
+            centerTypeText: centre.type?.localized,
             appointmentsCount: appointmentsCount,
             isAvailable: centre.isAvailable,
             partnerLogo: partnerLogo,

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -17,6 +17,7 @@ protocol CentreViewDataProvider {
     var phoneText: String? { get }
     var bookingButtonText: String { get }
     var vaccineTypesText: String? { get }
+    var centerTypeText: String? { get }
     var appointmentsCount: Int? { get }
     var isAvailable: Bool { get }
     var partnerLogo: UIImage? { get }
@@ -34,6 +35,7 @@ public struct CentreViewData: CentreViewDataProvider, Hashable, Identifiable {
     let phoneText: String?
     let bookingButtonText: String
     let vaccineTypesText: String?
+    let centerTypeText: String?
     let appointmentsCount: Int?
     let isAvailable: Bool
     let partnerLogo: UIImage?
@@ -57,6 +59,9 @@ final class CentreCell: UITableViewCell {
 
     @IBOutlet weak private var vaccineTypesContainer: UIStackView!
     @IBOutlet weak private var vaccineTypesLabel: UILabel!
+
+    @IBOutlet weak private var centerTypeContainer: UIStackView!
+    @IBOutlet weak private var centerTypeLabel: UILabel!
 
     @IBOutlet weak private var appointmentsLabel: UILabel!
 
@@ -131,6 +136,12 @@ final class CentreCell: UITableViewCell {
         vaccineTypesLabel.text = viewData.vaccineTypesText
         vaccineTypesLabel.font = Constant.labelPrimaryFont
         vaccineTypesLabel.textColor = Constant.labelPrimaryColor
+
+        centerTypeContainer.isHidden = viewData.centerTypeText == nil
+        centerTypeLabel.text = viewData.centerTypeText
+        centerTypeLabel.font = Constant.labelPrimaryFont
+        centerTypeLabel.textColor = Constant.labelPrimaryColor
+
         configureAppointmentsLabel(appointmentsCount: viewData.appointmentsCount, partnerLogo: viewData.partnerLogo, partnerName: viewData.partnerName)
     }
 
@@ -351,6 +362,7 @@ final class CentreCell: UITableViewCell {
             addressLabel,
             phoneButton,
             vaccineTypesLabel,
+            centerTypeLabel,
             followCentreButton,
             bookingButton,
             appointmentsLabel

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.swift
@@ -141,6 +141,7 @@ final class CentreCell: UITableViewCell {
         centerTypeLabel.text = viewData.centerTypeText
         centerTypeLabel.font = Constant.labelPrimaryFont
         centerTypeLabel.textColor = Constant.labelPrimaryColor
+        centerTypeLabel.numberOfLines = .zero
 
         configureAppointmentsLabel(appointmentsCount: viewData.appointmentsCount, partnerLogo: viewData.partnerLogo, partnerName: viewData.partnerName)
     }

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
@@ -25,79 +25,15 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="MXb-JO-A2C">
                                 <rect key="frame" x="0.0" y="0.0" width="445" height="456"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="io6-wY-Ctz">
-                                        <rect key="frame" x="0.0" y="0.0" width="445" height="35"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="cbv-IU-aYh">
-                                                <rect key="frame" x="20" y="0.0" width="405" height="35"/>
-                                                <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A32-ZV-tW7">
-                                                        <rect key="frame" x="0.0" y="0.0" width="25" height="35"/>
-                                                        <subviews>
-                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Qg-dM-6ND">
-                                                                <rect key="frame" x="4.3333333333333357" y="6.6666666666666679" width="16.666666666666668" height="22"/>
-                                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" secondItem="3Qg-dM-6ND" secondAttribute="height" multiplier="4:5" id="OyP-e8-3Fe"/>
-                                                                </constraints>
-                                                                <imageReference key="image" image="bolt.fill" catalog="system" symbolScale="default"/>
-                                                            </imageView>
-                                                        </subviews>
-                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="25" id="BfY-oD-4IP"/>
-                                                            <constraint firstItem="3Qg-dM-6ND" firstAttribute="centerX" secondItem="A32-ZV-tW7" secondAttribute="centerX" id="KeR-uq-4nE"/>
-                                                            <constraint firstItem="3Qg-dM-6ND" firstAttribute="centerY" secondItem="A32-ZV-tW7" secondAttribute="centerY" id="mfi-hH-7IM"/>
-                                                        </constraints>
-                                                    </view>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chronodoses Disponibles" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VaG-GN-B5Y">
-                                                        <rect key="frame" x="30" y="0.0" width="345" height="35"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="35" id="q9i-At-dbt"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AxV-yx-fh6">
-                                                        <rect key="frame" x="380" y="0.0" width="25" height="35"/>
-                                                        <subviews>
-                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zmD-rT-Qdm">
-                                                                <rect key="frame" x="4.3333333333333144" y="6.6666666666666679" width="16.666666666666668" height="22"/>
-                                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" secondItem="zmD-rT-Qdm" secondAttribute="height" multiplier="4:5" id="rP5-oI-hdU"/>
-                                                                </constraints>
-                                                                <imageReference key="image" image="bolt.fill" catalog="system" symbolScale="default"/>
-                                                            </imageView>
-                                                        </subviews>
-                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstItem="zmD-rT-Qdm" firstAttribute="centerY" secondItem="AxV-yx-fh6" secondAttribute="centerY" id="lRi-kL-dQ8"/>
-                                                            <constraint firstAttribute="width" constant="25" id="tdd-GF-ReY"/>
-                                                            <constraint firstItem="zmD-rT-Qdm" firstAttribute="centerX" secondItem="AxV-yx-fh6" secondAttribute="centerX" id="uQV-ev-H00"/>
-                                                        </constraints>
-                                                    </view>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
-                                        <color key="backgroundColor" name="mandy"/>
-                                        <constraints>
-                                            <constraint firstItem="cbv-IU-aYh" firstAttribute="top" secondItem="io6-wY-Ctz" secondAttribute="top" id="llS-Se-caw"/>
-                                            <constraint firstItem="cbv-IU-aYh" firstAttribute="leading" secondItem="io6-wY-Ctz" secondAttribute="leading" constant="20" symbolic="YES" id="pxK-gG-rXp"/>
-                                            <constraint firstAttribute="trailing" secondItem="cbv-IU-aYh" secondAttribute="trailing" constant="20" symbolic="YES" id="t79-pC-KQH"/>
-                                            <constraint firstAttribute="bottom" secondItem="cbv-IU-aYh" secondAttribute="bottom" id="u1n-fl-AhP"/>
-                                        </constraints>
-                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ocW-ZY-7YO">
-                                        <rect key="frame" x="0.0" y="35" width="445" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="445" height="16"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="KO0-Lt-bRO"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2ff-AN-hBk">
-                                        <rect key="frame" x="0.0" y="51" width="445" height="405"/>
+                                        <rect key="frame" x="0.0" y="16" width="445" height="440"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qjh-hq-U7W">
                                                 <rect key="frame" x="20" y="0.0" width="405" height="314.33333333333331"/>
@@ -226,7 +162,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5H-Fb-wwZ">
-                                                        <rect key="frame" x="0.0" y="130" width="405" height="25"/>
+                                                        <rect key="frame" x="0.0" y="130" width="405" height="50"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="juo-5y-WUd">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="50"/>
@@ -259,7 +195,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Vaccine Types" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="tFU-d1-nKp">
-                                                                <rect key="frame" x="35" y="0.0" width="370" height="25"/>
+                                                                <rect key="frame" x="35" y="0.0" width="370" height="50"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -268,10 +204,10 @@
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="D93-Hu-Gf5" userLabel="Center Type Container">
-                                                        <rect key="frame" x="0.0" y="165" width="405" height="50"/>
+                                                        <rect key="frame" x="0.0" y="190" width="405" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WUp-5M-JlX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WHc-HF-QFY">
                                                                         <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -301,7 +237,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Center Type" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="52d-Mz-Oxe" userLabel="Center Type">
-                                                                <rect key="frame" x="35" y="0.0" width="370" height="50"/>
+                                                                <rect key="frame" x="35" y="0.0" width="370" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -393,8 +329,6 @@
                 <outlet property="cellContentView" destination="h5C-Xa-hUC" id="2xr-L7-qUy"/>
                 <outlet property="centerTypeContainer" destination="D93-Hu-Gf5" id="Zhz-Sh-Bzs"/>
                 <outlet property="centerTypeLabel" destination="52d-Mz-Oxe" id="aNS-7y-zGc"/>
-                <outlet property="chronoDoseLabel" destination="VaG-GN-B5Y" id="gno-FZ-CbZ"/>
-                <outlet property="chronoDoseViewContainer" destination="io6-wY-Ctz" id="6ny-D1-xNU"/>
                 <outlet property="dateContainer" destination="ryg-di-598" id="I2m-Ji-RMO"/>
                 <outlet property="dateLabel" destination="vca-O5-a2x" id="FHh-uY-y3T"/>
                 <outlet property="followCentreButton" destination="zAo-oT-oBY" id="rka-Ja-HMJ"/>

--- a/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
+++ b/ViteMaDose/Views/CentresList/Cells/CentreCell.xib
@@ -12,34 +12,98 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="346" id="Ew8-MU-ew9" customClass="CentreCell" customModule="ViteMaDose" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="346"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="480" id="Ew8-MU-ew9" customClass="CentreCell" customModule="ViteMaDose" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="493" height="480"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ew8-MU-ew9" id="Fvy-BW-4Kh">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="346"/>
+                <rect key="frame" x="0.0" y="0.0" width="493" height="480"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h5C-Xa-hUC">
-                        <rect key="frame" x="24" y="12" width="366" height="322"/>
+                        <rect key="frame" x="24" y="12" width="445" height="456"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="MXb-JO-A2C">
-                                <rect key="frame" x="0.0" y="0.0" width="366" height="322"/>
+                                <rect key="frame" x="0.0" y="0.0" width="445" height="456"/>
                                 <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="io6-wY-Ctz">
+                                        <rect key="frame" x="0.0" y="0.0" width="445" height="35"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="cbv-IU-aYh">
+                                                <rect key="frame" x="20" y="0.0" width="405" height="35"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A32-ZV-tW7">
+                                                        <rect key="frame" x="0.0" y="0.0" width="25" height="35"/>
+                                                        <subviews>
+                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Qg-dM-6ND">
+                                                                <rect key="frame" x="4.3333333333333357" y="6.6666666666666679" width="16.666666666666668" height="22"/>
+                                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="3Qg-dM-6ND" secondAttribute="height" multiplier="4:5" id="OyP-e8-3Fe"/>
+                                                                </constraints>
+                                                                <imageReference key="image" image="bolt.fill" catalog="system" symbolScale="default"/>
+                                                            </imageView>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="25" id="BfY-oD-4IP"/>
+                                                            <constraint firstItem="3Qg-dM-6ND" firstAttribute="centerX" secondItem="A32-ZV-tW7" secondAttribute="centerX" id="KeR-uq-4nE"/>
+                                                            <constraint firstItem="3Qg-dM-6ND" firstAttribute="centerY" secondItem="A32-ZV-tW7" secondAttribute="centerY" id="mfi-hH-7IM"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chronodoses Disponibles" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VaG-GN-B5Y">
+                                                        <rect key="frame" x="30" y="0.0" width="345" height="35"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="35" id="q9i-At-dbt"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AxV-yx-fh6">
+                                                        <rect key="frame" x="380" y="0.0" width="25" height="35"/>
+                                                        <subviews>
+                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zmD-rT-Qdm">
+                                                                <rect key="frame" x="4.3333333333333144" y="6.6666666666666679" width="16.666666666666668" height="22"/>
+                                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="zmD-rT-Qdm" secondAttribute="height" multiplier="4:5" id="rP5-oI-hdU"/>
+                                                                </constraints>
+                                                                <imageReference key="image" image="bolt.fill" catalog="system" symbolScale="default"/>
+                                                            </imageView>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstItem="zmD-rT-Qdm" firstAttribute="centerY" secondItem="AxV-yx-fh6" secondAttribute="centerY" id="lRi-kL-dQ8"/>
+                                                            <constraint firstAttribute="width" constant="25" id="tdd-GF-ReY"/>
+                                                            <constraint firstItem="zmD-rT-Qdm" firstAttribute="centerX" secondItem="AxV-yx-fh6" secondAttribute="centerX" id="uQV-ev-H00"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" name="mandy"/>
+                                        <constraints>
+                                            <constraint firstItem="cbv-IU-aYh" firstAttribute="top" secondItem="io6-wY-Ctz" secondAttribute="top" id="llS-Se-caw"/>
+                                            <constraint firstItem="cbv-IU-aYh" firstAttribute="leading" secondItem="io6-wY-Ctz" secondAttribute="leading" constant="20" symbolic="YES" id="pxK-gG-rXp"/>
+                                            <constraint firstAttribute="trailing" secondItem="cbv-IU-aYh" secondAttribute="trailing" constant="20" symbolic="YES" id="t79-pC-KQH"/>
+                                            <constraint firstAttribute="bottom" secondItem="cbv-IU-aYh" secondAttribute="bottom" id="u1n-fl-AhP"/>
+                                        </constraints>
+                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ocW-ZY-7YO">
-                                        <rect key="frame" x="0.0" y="0.0" width="366" height="16"/>
+                                        <rect key="frame" x="0.0" y="35" width="445" height="16"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="KO0-Lt-bRO"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2ff-AN-hBk">
-                                        <rect key="frame" x="0.0" y="16" width="366" height="306"/>
+                                        <rect key="frame" x="0.0" y="51" width="445" height="405"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qjh-hq-U7W">
-                                                <rect key="frame" x="20" y="0.0" width="326" height="279.33333333333331"/>
+                                                <rect key="frame" x="20" y="0.0" width="405" height="314.33333333333331"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ryg-di-598">
-                                                        <rect key="frame" x="0.0" y="0.0" width="326" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="405" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XXI-0S-lWr">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -61,7 +125,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Date Label" textAlignment="natural" lineBreakMode="middleTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vca-O5-a2x">
-                                                                <rect key="frame" x="35" y="0.0" width="291" height="20.333333333333332"/>
+                                                                <rect key="frame" x="35" y="0.0" width="370" height="20.333333333333332"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
@@ -72,7 +136,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hTX-gS-qFO">
-                                                        <rect key="frame" x="0.0" y="35" width="326" height="50"/>
+                                                        <rect key="frame" x="0.0" y="35" width="405" height="50"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z5d-ai-10V">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="50"/>
@@ -104,16 +168,16 @@
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D2y-su-ffI">
-                                                                <rect key="frame" x="35" y="0.0" width="291" height="50"/>
+                                                                <rect key="frame" x="35" y="0.0" width="370" height="50"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Name Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="eYu-df-GbP">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="291" height="20.333333333333332"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="370" height="20.333333333333332"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Adress Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Pg-Tm-YCx">
-                                                                        <rect key="frame" x="0.0" y="25.333333333333329" width="291" height="24.666666666666671"/>
+                                                                        <rect key="frame" x="0.0" y="25.333333333333329" width="370" height="24.666666666666671"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -124,7 +188,7 @@
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Tvm-1z-GuO">
-                                                        <rect key="frame" x="0.0" y="95" width="326" height="25"/>
+                                                        <rect key="frame" x="0.0" y="95" width="405" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Nc-ap-Vf5">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -146,13 +210,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="headTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d0x-2N-C1e">
-                                                                <rect key="frame" x="35" y="0.0" width="231" height="25"/>
+                                                                <rect key="frame" x="35" y="0.0" width="310" height="25"/>
                                                                 <state key="normal" title="Phone Button">
                                                                     <color key="titleColor" systemColor="labelColor"/>
                                                                 </state>
                                                             </button>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pmr-3p-nfw" userLabel="Spacer">
-                                                                <rect key="frame" x="276" y="0.0" width="50" height="25"/>
+                                                                <rect key="frame" x="355" y="0.0" width="50" height="25"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             </view>
                                                         </subviews>
@@ -162,7 +226,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5H-Fb-wwZ">
-                                                        <rect key="frame" x="0.0" y="130" width="326" height="50"/>
+                                                        <rect key="frame" x="0.0" y="130" width="405" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="juo-5y-WUd">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="50"/>
@@ -195,7 +259,49 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Vaccine Types" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="tFU-d1-nKp">
-                                                                <rect key="frame" x="35" y="0.0" width="291" height="50"/>
+                                                                <rect key="frame" x="35" y="0.0" width="370" height="25"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="D93-Hu-Gf5" userLabel="Center Type Container">
+                                                        <rect key="frame" x="0.0" y="165" width="405" height="50"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WUp-5M-JlX">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="50"/>
+                                                                <subviews>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WHc-HF-QFY">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                        <subviews>
+                                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bandage.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="SXy-Qz-meK">
+                                                                                <rect key="frame" x="2" y="2" width="21" height="21"/>
+                                                                                <color key="tintColor" systemColor="secondaryLabelColor"/>
+                                                                            </imageView>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="bottom" secondItem="SXy-Qz-meK" secondAttribute="bottom" constant="2" id="2ei-00-heU"/>
+                                                                            <constraint firstAttribute="width" constant="25" id="5RH-iq-gBh"/>
+                                                                            <constraint firstItem="SXy-Qz-meK" firstAttribute="top" secondItem="WHc-HF-QFY" secondAttribute="top" constant="2" id="ERo-4Z-LZQ"/>
+                                                                            <constraint firstAttribute="trailing" secondItem="SXy-Qz-meK" secondAttribute="trailing" constant="2" id="dfi-lF-0sx"/>
+                                                                            <constraint firstAttribute="height" constant="25" id="f4a-3U-CD2"/>
+                                                                            <constraint firstItem="SXy-Qz-meK" firstAttribute="leading" secondItem="WHc-HF-QFY" secondAttribute="leading" constant="2" id="wZH-LK-ZKH"/>
+                                                                        </constraints>
+                                                                    </view>
+                                                                </subviews>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstItem="WHc-HF-QFY" firstAttribute="centerX" secondItem="WUp-5M-JlX" secondAttribute="centerX" id="Il5-9t-iXJ"/>
+                                                                    <constraint firstItem="WHc-HF-QFY" firstAttribute="top" secondItem="WUp-5M-JlX" secondAttribute="top" id="Mr4-5A-lIy"/>
+                                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="25" id="bYw-hq-hZl"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="oK2-fo-uuG"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Center Type" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="52d-Mz-Oxe" userLabel="Center Type">
+                                                                <rect key="frame" x="35" y="0.0" width="370" height="50"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -204,17 +310,17 @@
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="AGf-cx-Qph">
-                                                        <rect key="frame" x="0.0" y="190" width="326" height="59"/>
+                                                        <rect key="frame" x="0.0" y="225" width="405" height="59"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XKQ-RD-2fb" userLabel="Spacer">
-                                                                <rect key="frame" x="0.0" y="0.0" width="326" height="15"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="405" height="15"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="15" id="sLN-BO-maJ"/>
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Jdb-ng-o1D">
-                                                                <rect key="frame" x="0.0" y="15" width="326" height="44"/>
+                                                                <rect key="frame" x="0.0" y="15" width="405" height="44"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zAo-oT-oBY">
                                                                         <rect key="frame" x="0.0" y="0.0" width="45" height="44"/>
@@ -229,7 +335,7 @@
                                                                         </state>
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4oP-8v-7f8">
-                                                                        <rect key="frame" x="55" y="0.0" width="271" height="44"/>
+                                                                        <rect key="frame" x="55" y="0.0" width="350" height="44"/>
                                                                         <color key="backgroundColor" name="AccentColor"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="44" id="qZE-G5-rTF"/>
@@ -243,7 +349,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Appointments Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hFB-rb-sEa">
-                                                        <rect key="frame" x="0.0" y="259" width="326" height="20.333333333333314"/>
+                                                        <rect key="frame" x="0.0" y="294" width="405" height="20.333333333333314"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -285,6 +391,10 @@
                 <outlet property="appointmentsLabel" destination="hFB-rb-sEa" id="Fbr-68-cnm"/>
                 <outlet property="bookingButton" destination="4oP-8v-7f8" id="dbo-sT-TaC"/>
                 <outlet property="cellContentView" destination="h5C-Xa-hUC" id="2xr-L7-qUy"/>
+                <outlet property="centerTypeContainer" destination="D93-Hu-Gf5" id="Zhz-Sh-Bzs"/>
+                <outlet property="centerTypeLabel" destination="52d-Mz-Oxe" id="aNS-7y-zGc"/>
+                <outlet property="chronoDoseLabel" destination="VaG-GN-B5Y" id="gno-FZ-CbZ"/>
+                <outlet property="chronoDoseViewContainer" destination="io6-wY-Ctz" id="6ny-D1-xNU"/>
                 <outlet property="dateContainer" destination="ryg-di-598" id="I2m-Ji-RMO"/>
                 <outlet property="dateLabel" destination="vca-O5-a2x" id="FHh-uY-y3T"/>
                 <outlet property="followCentreButton" destination="zAo-oT-oBY" id="rka-Ja-HMJ"/>
@@ -295,10 +405,11 @@
                 <outlet property="vaccineTypesContainer" destination="E5H-Fb-wwZ" id="Qsh-oe-gDw"/>
                 <outlet property="vaccineTypesLabel" destination="tFU-d1-nKp" id="ORj-6R-GLH"/>
             </connections>
-            <point key="canvasLocation" x="244.92753623188409" y="254.34782608695653"/>
+            <point key="canvasLocation" x="302.17391304347831" y="308.96739130434787"/>
         </tableViewCell>
     </objects>
     <resources>
+        <image name="bandage.fill" catalog="system" width="128" height="124"/>
         <image name="bell.fill" catalog="system" width="128" height="124"/>
         <image name="calendar" catalog="system" width="128" height="106"/>
         <image name="location.fill" catalog="system" width="128" height="121"/>


### PR DESCRIPTION
## Description
Other frontends display the type of vaccination center.
Display such detail can help user to find a vaccinodrome, a general practitioner or a drugstore.

## Changes
- Update XIB of _CenterCell_ to add label and image (SFSymbol compatible with IOS 13)
- Update view data and beans to deal with type
- Update localizables to display suitable wording
- Test a11y (VocieOver and big text sizes)

## Related issue

_Link to the [Github issue #144](https://github.com/CovidTrackerFr/vitemadose-ios/issues/144)_

## What I tested
- Tested with simulator (iPhone SE 2nd Gen - IOS 13)
- Tested with device (iPhone 12 Pro - iOS 15)
- Tested a11Y (big size, Voice Over), and display of centers (small cities, big cities, counties)

## Regression risks
- None ; _type_ field remains optional, display it only if defined

## Screenshots
![IMG_0058](https://user-images.githubusercontent.com/7559007/148132173-c51e4879-d7cc-4411-b2af-4f1a1da9a42d.PNG)

## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
