### PR TITLE
[#172] Unmanaged "pharmacie" type for centre

### DIFF
--- a/ViteMaDose/Models/VaccinationCentre.swift
+++ b/ViteMaDose/Models/VaccinationCentre.swift
@@ -95,23 +95,23 @@ extension VaccinationCentre {
     // MARK: Centre Type
 
     public enum CentreType: String, Codable, Hashable {
-        case vaccinationCenter = "vaccination-center"
-        case drugstore = "drugstore"
-        case generalPractitioner = "general-practitioner"
-        case medecin = "medecin"
+        case vaccinationCenter
+        case drugstore
+        case generalPractitioner
+        case medecin
 
         public init?(rawValue: String) {
             switch rawValue {
             case "vaccination-center":
                 self = .vaccinationCenter
-            case "drugstore":
+            case "drugstore", "pharmacie":
                 self = .drugstore
             case "general-practitioner":
                 self = .generalPractitioner
             case "medecin":
                 self = .medecin
             default:
-                assertionFailure("Received value '\(rawValue) but it's not managed")
+                Log.w("Received value '\(rawValue) but it's not managed")
                 return nil
             }
         }


### PR DESCRIPTION
## Description
Deal with vaccination centre with type "pharmacie"

## Changes
Update enum for _CentreType_

## Related issue

_Link to the [Github issue #172](https://github.com/CovidTrackerFr/vitemadose-ios/issues/172)_

## What I tested
- Tested plenty of locations, it's ok

## Regression risks
- None, bug is not yet in production, _nil_ case is managed

## Screenshots
Not relevant

## Checklist
- [ ] I have installed SwiftLint and made sure code formatting is correct
- [ ] I have performed a self-review of my own code
- [ ] I tested my changes on real device
- [ ] My changes generate no new warnings
- [ ] I have commented my code in hard-to-understand areas
- [ ] Any dependent changes have been merged into **develop**
- [ ] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
