### PR TITLE
[#148] Location slider for maximal radius

### DIFF
--- a/ViteMaDose/Helpers/Utils/UserDefaultsUtils.swift
+++ b/ViteMaDose/Helpers/Utils/UserDefaultsUtils.swift
@@ -107,6 +107,14 @@ extension UserDefaults {
         }
     }
 
+    // MARK: - Max Distance To Vaccination Centre
+
+    /// The value defined in the Setting.bundle. Can be 0 if nothing was defined.
+    /// Used thee key **vaccination_centres_list_radius_in_km** defined in the Root.plist.
+    var maxDistanceToVaccinationCentre: Int {
+        return integer(forKey: "vaccination_centres_list_radius_in_km")
+    }
+
     // MARK: - Helpers
 
     var hasFollowedCentres: Bool {

--- a/ViteMaDose/Networking/RemoteConfig.swift
+++ b/ViteMaDose/Networking/RemoteConfig.swift
@@ -73,8 +73,14 @@ extension RemoteConfiguration {
         }
     }
 
+    /// If the user has defined a maximal radius in the app settings, returns it.
+    /// Otherwise returns the value from the remote configuration.
     var vaccinationCentresListRadiusInKm: NSNumber {
-        return configuration.configValue(forKey: "vaccination_centres_list_radius_in_km").numberValue
+        guard case let maxDistanceInAppSettings = UserDefaults.shared.maxDistanceToVaccinationCentre,
+              maxDistanceInAppSettings > 0 else {
+            return configuration.configValue(forKey: "vaccination_centres_list_radius_in_km").numberValue
+        }
+        return NSNumber(value: maxDistanceInAppSettings)
     }
 
     var vaccinationCentresListRadiusInMeters: Double {

--- a/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ViteMaDose/Resources/Localization/fr.lproj/Localizable.strings
@@ -135,4 +135,4 @@
 "settings.sourcecode.title" = "Code source";
 "settings.sourcecode.subtitle" = "Retrouvez le code source de l'application sur GitHub";
 "settings.system.title" = "Avancé";
-"settings.system.subtitle" = "Accédez aux réglages avancés de l'app";
+"settings.system.subtitle" = "Accédez aux réglages avancés de l'app dont la distance maximale des lieux de vaccination";

--- a/ViteMaDose/Settings.bundle/Root.plist
+++ b/ViteMaDose/Settings.bundle/Root.plist
@@ -1,24 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>StringsTable</key>
-    <string>Root</string>
-    <key>PreferenceSpecifiers</key>
-    <array>
-        <dict>
-            <key>Type</key>
-            <string>PSChildPaneSpecifier</string>
-            <key>Title</key>
-            <string>Licenses</string>
-            <key>File</key>
-            <string>com.mono0926.LicensePlist</string>
-        </dict>
-        <dict>
-            <key>Type</key>
-            <string>PSGroupSpecifier</string>
-            <key>FooterText</key>
-            <string>Copyright (c) 2021 - CovidTracker (covidtracker.fr)</string>
-        </dict>
-    </array>
+	<key>StringsTable</key>
+	<string>Root</string>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Distance maximale des lieux de vaccination (en km)</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Définir</string>
+			<key>Key</key>
+			<string>vaccination_centres_list_radius_in_km</string>
+			<key>DefaultValue</key>
+			<string>50</string>
+			<key>Titles</key>
+			<array>
+				<string>Moins de 1 km</string>
+				<string>Moins de 2 km</string>
+				<string>Moins de 5 km</string>
+				<string>Moins de 10 km</string>
+				<string>Jusque 20 km</string>
+				<string>Jusque 50 km</string>
+				<string>Jusque 100 km</string>
+				<string>Jusque 150 km</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>1</string>
+				<string>2</string>
+				<string>5</string>
+				<string>10</string>
+				<string>20</string>
+				<string>50</string>
+				<string>100</string>
+				<string>150</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Licences</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+			<key>Title</key>
+			<string>Liste des composants tiers</string>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>FooterText</key>
+			<string>Copyright (c) 2021 - CovidTracker (covidtracker.fr)</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
In settings of the app, let the user define the maximal radius to get the vaccination centres.
This value is stored in user defaults, and if undefined is replaced by remote configuration.
Thus the user can find closer centers with the same granularity in the web front.

## Changes
- Update Setting.bundle
- Update computed property in remote config

## Related issue
_Link to the [Github issue #148](https://github.com/CovidTrackerFr/vitemadose-ios/issues/148)_

## What I tested
- Tested with simulator (iPhon SE 2nd Gen - iOS 13.5) and device (iPhone 12 Pro - iOS 15.1)
- Tested with one of the most "isolated" city (Saint Martin de Lansuscle)

## Regression risks
Nothing identified

## Screenshots

![IMG_0126](https://user-images.githubusercontent.com/7559007/149196882-6ccb81d2-22f5-4267-b67c-533eee370cf2.PNG)
![IMG_0127](https://user-images.githubusercontent.com/7559007/149196887-457cff6c-4920-4a55-a452-f97eb9d1a440.PNG)

## Checklist
- [x] I have installed SwiftLint and made sure code formatting is correct
- [x] I have performed a self-review of my own code
- [x] I tested my changes on real device
- [x] My changes generate no new warnings
- [x] I have commented my code in hard-to-understand areas
- [x] Any dependent changes have been merged into **develop**
- [x] I have checked there aren't other open [Pull Requests](https://github.com/CovidTrackerFr/vitemadose-ios/pulls) for the same update/change
